### PR TITLE
Add go_package

### DIFF
--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -21,6 +21,8 @@ import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // A branch on a specific Module.
 message Branch {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -21,6 +21,8 @@ import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/module/v1beta1/resource.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // Operate on Branches.
 service BranchService {
   // Get Branches by ID or name.

--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -21,6 +21,8 @@ import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // A commit on a specific module.
 //
 // Commits can be associated with multiple Branches.

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -22,6 +22,8 @@ import "buf/registry/module/v1beta1/vcs_commit.proto";
 import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // Operate on Commits.
 service CommitService {
   // Resolve commits by Commit ID, Module, Branch, Tag, or VCSCommit.

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -20,6 +20,8 @@ import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // A module within the BSR.
 message Module {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -20,6 +20,8 @@ import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/owner/v1beta1/owner.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // Operate on Modules.
 service ModuleService {
   // Get Modules by id or name.

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -19,6 +19,8 @@ package buf.registry.module.v1beta1;
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // A reference to any of these resources:
 //   - Module
 //   - Commit

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -21,6 +21,8 @@ import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // A tag on a specific Module.
 //
 // Many Tags can be associated with a single Commit.

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -21,6 +21,8 @@ import "buf/registry/module/v1beta1/resource.proto";
 import "buf/registry/module/v1beta1/tag.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // Operate on Tags.
 service TagService {
   // Get Tags by id or name.

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -21,6 +21,8 @@ import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // VCSCommit is a commit from a specific VCS associated with a specific Module.
 //
 // Many VCSCommits can be associated with a single Commit.

--- a/buf/registry/module/v1beta1/vcs_commit_service.proto
+++ b/buf/registry/module/v1beta1/vcs_commit_service.proto
@@ -20,6 +20,8 @@ import "buf/registry/module/v1beta1/resource.proto";
 import "buf/registry/module/v1beta1/vcs_commit.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+
 // Operate on VCSCommits.
 service VCSCommitService {
   // Get VCSCommits by id or name.

--- a/buf/registry/owner/v1beta1/organization.proto
+++ b/buf/registry/owner/v1beta1/organization.proto
@@ -20,6 +20,8 @@ import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1beta1";
+
 // Organization is an organization on the BSR.
 //
 // A name uniquely identifies an Organization, however name is mutable.

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -20,6 +20,8 @@ import "buf/registry/owner/v1beta1/organization.proto";
 import "buf/registry/owner/v1beta1/user.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1beta1";
+
 // Operate on Organizations
 service OrganizationService {
   // Get Organizations by id or name.

--- a/buf/registry/owner/v1beta1/owner.proto
+++ b/buf/registry/owner/v1beta1/owner.proto
@@ -21,6 +21,8 @@ import "buf/registry/owner/v1beta1/user.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1beta1";
+
 // A User or Organization.
 message Owner {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;

--- a/buf/registry/owner/v1beta1/owner_service.proto
+++ b/buf/registry/owner/v1beta1/owner_service.proto
@@ -19,6 +19,8 @@ package buf.registry.owner.v1beta1;
 import "buf/registry/owner/v1beta1/owner.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1beta1";
+
 // Operate on Users and Organizations in situations where you only
 // know a reference to an owner, without knowing whether or not that
 // owner is a User or Organization.

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -20,6 +20,8 @@ import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1beta1";
+
 // A user on the BSR.
 //
 // A name uniquely identifies a User, however name is mutable.

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -20,6 +20,8 @@ import "buf/registry/owner/v1beta1/organization.proto";
 import "buf/registry/owner/v1beta1/user.proto";
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1beta1";
+
 // Operate on Users.
 service UserService {
   // Get Users by id or name.

--- a/buf/registry/priv/extension/v1beta1/extension.proto
+++ b/buf/registry/priv/extension/v1beta1/extension.proto
@@ -18,6 +18,8 @@ package buf.registry.priv.extension.v1beta1;
 
 import "google/protobuf/descriptor.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/priv/extension/v1beta1";
+
 extend google.protobuf.MessageOptions {
   // Constraints on a message.
   MessageConstraints message = 1160;

--- a/buf/registry/storage/v1beta1/storage.proto
+++ b/buf/registry/storage/v1beta1/storage.proto
@@ -18,6 +18,8 @@ package buf.registry.storage.v1beta1;
 
 import "buf/validate/validate.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/storage/v1beta1";
+
 // A digest.
 message Digest {
   // The type of Digest.


### PR DESCRIPTION
In order to ensure that all generated code comes from the correct package, add the go_package option (similar to protovalidate) to all .proto files.

This should also serve as a reminder for users that generated registry code should come from generated SDKs.