### PR TITLE
Fix *_id fields to use uuid validator

### DIFF
--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -140,7 +140,7 @@ message UpdateModulesRequest {
       // The id of the release Branch of the Module.
       //
       // This Branch must already exist.
-      string release_branch_id = 7 [(buf.validate.field).string.max_len = 255];
+      string release_branch_id = 7 [(buf.validate.field).string.uuid = true];
       // The name of the release Branch of the Module.
       //
       // This Branch must already exist.

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -61,7 +61,7 @@ message Tag {
   // The id of the Commit associated with the Tag.
   string commit_id = 7 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.uuid = true
   ];
   // The Digest of the Commit associated with the Tag.
   buf.registry.storage.v1beta1.Digest commit_digest = 8 [(buf.validate.field).required = true];

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -97,7 +97,7 @@ message CreateTagsRequest {
     // The id of the Commit associated with the Tag.
     string commit_id = 3 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.uuid = true
     ];
   }
   // The Tags to create.

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -67,7 +67,7 @@ message VCSCommit {
   // The id of the Commit associated with the VCSCommit.
   string commit_id = 8 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.uuid = true
   ];
   // The Digest of the Commit associated with the VCSCommit.
   buf.registry.storage.v1beta1.Digest commit_digest = 9 [(buf.validate.field).required = true];


### PR DESCRIPTION
All fields that end in `_id` except `spdx_license_id` are UUIDs to my knowledge and should use `string.uuid` instead of `string.max_len` for validation.

<!-- Related issue: BSR-2930 -->