### PR TITLE
Adjust limits for trivial cases where v1alpha1 already has a defined, static limit

### DIFF
--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -43,7 +43,7 @@ message Branch {
   // Unique within a given Module.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 250
   ];
   // The id of the User or Organization that owns the Module that the Branch is associated with.
   string owner_id = 5 [
@@ -104,6 +104,6 @@ message BranchFullName {
   // The name of the Branch.
   string branch = 3 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 250
   ];
 }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -167,7 +167,7 @@ message CreateCommitsRequest {
   //
   // If empty, the default branch is assumed as the only branch.
   repeated string branch_names = 3 [(buf.validate.field).repeated.items = {
-    string: {max_len: 255}
+    string: {max_len: 250}
   }];
   // The names of Tags that should be associated with this Commit.
   //

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -175,7 +175,7 @@ message CreateCommitsRequest {
   // this will change in the future when we allow Tags to move. If the Tag does not
   // currently exist, a new Tag will be created for each name.
   repeated string tag_names = 4 [(buf.validate.field).repeated.items = {
-    string: {max_len: 255}
+    string: {max_len: 250}
   }];
   // Associated VCS commit information.
   //

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -58,7 +58,7 @@ message Module {
     (buf.validate.field).enum.defined_only = true
   ];
   // The configurable description of the Module.
-  string description = 8 [(buf.validate.field).string.max_len = 1023];
+  string description = 8 [(buf.validate.field).string.max_len = 350];
   // The configurable URL in the description of the Module,
   string url = 9 [
     (buf.validate.field).string.uri = true,

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -100,7 +100,7 @@ message CreateModulesRequest {
       (buf.validate.field).enum.defined_only = true
     ];
     // The configurable description of the Module.
-    string description = 4 [(buf.validate.field).string.max_len = 1023];
+    string description = 4 [(buf.validate.field).string.max_len = 350];
     // The configurable URL in the description of the module.
     string url = 5 [
       (buf.validate.field).string.uri = true,
@@ -130,7 +130,7 @@ message UpdateModulesRequest {
     // The deprecation status of the module.
     optional ModuleState state = 4 [(buf.validate.field).enum.defined_only = true];
     // The configurable description of the module.
-    optional string description = 5 [(buf.validate.field).string.max_len = 1023];
+    optional string description = 5 [(buf.validate.field).string.max_len = 350];
     // uThe configurable URL in the description of the module.
     optional string url = 6 [
       (buf.validate.field).string.uri = true,

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -109,7 +109,7 @@ message CreateModulesRequest {
     // The name of the release Branch of the module.
     //
     // If not set, the release branch will be "main" upon creation.
-    string release_branch_name = 6 [(buf.validate.field).string.max_len = 255];
+    string release_branch_name = 6 [(buf.validate.field).string.max_len = 250];
   }
   // The Modules to create.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
@@ -144,7 +144,7 @@ message UpdateModulesRequest {
       // The name of the release Branch of the Module.
       //
       // This Branch must already exist.
-      string release_branch_name = 8 [(buf.validate.field).string.max_len = 255];
+      string release_branch_name = 8 [(buf.validate.field).string.max_len = 250];
     }
   }
   // The Modules to update.

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -82,7 +82,7 @@ message ResourceFullName {
   ];
   oneof child {
     string branch_name = 3 [(buf.validate.field).string.max_len = 250];
-    string tag_name = 4 [(buf.validate.field).string.max_len = 255];
+    string tag_name = 4 [(buf.validate.field).string.max_len = 250];
     string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
     string ref = 6;
   }

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -81,7 +81,7 @@ message ResourceFullName {
     (buf.validate.field).string.max_len = 255
   ];
   oneof child {
-    string branch_name = 3 [(buf.validate.field).string.max_len = 255];
+    string branch_name = 3 [(buf.validate.field).string.max_len = 250];
     string tag_name = 4 [(buf.validate.field).string.max_len = 255];
     string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
     string ref = 6;

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -46,7 +46,7 @@ message Tag {
   // Unique within a given Module.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 250
   ];
   // The id of the User or Organization that owns the Module that the Tag is associated with.
   string owner_id = 5 [
@@ -107,6 +107,6 @@ message TagFullName {
   // The Tag name.
   string tag = 3 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 250
   ];
 }

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -92,7 +92,7 @@ message CreateTagsRequest {
     // The Tag name.
     string name = 2 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 250
     ];
     // The id of the Commit associated with the Tag.
     string commit_id = 3 [

--- a/buf/registry/owner/v1beta1/organization.proto
+++ b/buf/registry/owner/v1beta1/organization.proto
@@ -43,7 +43,7 @@ message Organization {
     (buf.validate.field).string.max_len = 255
   ];
   // The configurable description of the Organization.
-  string description = 5 [(buf.validate.field).string.max_len = 1023];
+  string description = 5 [(buf.validate.field).string.max_len = 350];
   // The configurable URL that represents the homepage for an Organization.
   string url = 6 [
     (buf.validate.field).string.uri = true,

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -90,7 +90,7 @@ message CreateOrganizationsRequest {
       (buf.validate.field).string.max_len = 255
     ];
     // The configurable description of the Organization.
-    string description = 2 [(buf.validate.field).string.max_len = 1023];
+    string description = 2 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for an Organization.
     string url = 3 [
       (buf.validate.field).string.uri = true,
@@ -116,7 +116,7 @@ message UpdateOrganizationsRequest {
     // The organization to update.
     OrganizationRef organization_ref = 1 [(buf.validate.field).required = true];
     // The configurable description of the Organization.
-    optional string description = 2 [(buf.validate.field).string.max_len = 1023];
+    optional string description = 2 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for an Organization.
     optional string url = 3 [
       (buf.validate.field).string.uri = true,

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -58,7 +58,7 @@ message User {
     (buf.validate.field).enum.defined_only = true
   ];
   // The configurable description of the User.
-  string description = 8 [(buf.validate.field).string.max_len = 1023];
+  string description = 8 [(buf.validate.field).string.max_len = 350];
   // The configurable URL that represents the homepage for a User.
   string url = 9 [
     (buf.validate.field).string.uri = true,

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -98,7 +98,7 @@ message CreateUsersRequest {
     // If not set, the default USER_SERVER_ROLE_STANDARD is used..
     UserServerRole server_role = 3 [(buf.validate.field).enum.defined_only = true];
     // The configurable description of the User.
-    string description = 4 [(buf.validate.field).string.max_len = 1023];
+    string description = 4 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for a User.
     string url = 5 [
       (buf.validate.field).string.uri = true,
@@ -128,7 +128,7 @@ message UpdateUsersRequest {
     // The role that the User has at the BSR instance level.
     optional UserServerRole server_role = 3 [(buf.validate.field).enum.defined_only = true];
     // The configurable description of the User.
-    optional string description = 4 [(buf.validate.field).string.max_len = 1023];
+    optional string description = 4 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for a User.
     optional string url = 5 [
       (buf.validate.field).string.uri = true,


### PR DESCRIPTION
This regards the following limits:

* Metadata descriptions, on users, organizations, and modules;
* Branch names
* Tag names

Other validation rules have a less-trivial path forward, as they either do not have exactly-defined limits or they have limits that are not statically known, and thus may require us to relax validation in the public BSR to unify across the board.