### PR TITLE
Make federation a first-class citizen

### DIFF
--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -27,31 +27,38 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 message Branch {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
-  // The id of the Branch.
+  // The id of the Branch within the BSR instance denoted by registry_hostname.
   string id = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
+  // The hostname of the registry of the BSR instance that the Branch is on.
+  string registry_hostname = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   // The time the Branch was created on the BSR.
-  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
   // The last time the Branch was updated on the BSR.
   //
   // This is typically the last time a Commit was pushed to the Branch.
-  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp update_time = 4 [(buf.validate.field).required = true];
   // The name of the Branch.
   //
   // Unique within a given Module.
-  string name = 4 [
+  string name = 5 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250
   ];
-  // The id of the User or Organization that owns the Module that the Branch is associated with.
-  string owner_id = 5 [
+  // The id of the User or Organization within the BSR instance denoted by registry_hostname
+  // that owns the Module that the Branch is associated with.
+  string owner_id = 6 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
-  // The id of the Module that the Branch is associated with.
-  string module_id = 6 [
+  // The id of the Module within the BSR instance denoted by registry_hostname
+  // that the Branch is associated with.
+  string module_id = 7 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
@@ -59,14 +66,15 @@ message Branch {
   //
   // Only one Branch per module will be marked as the release Branch.
   // TODO: enum?
-  bool is_release = 9 [(buf.validate.field).required = true];
-  // The id of the latest Commit created on the Branch.
-  string latest_commit_id = 10 [
+  bool is_release = 8 [(buf.validate.field).required = true];
+  // The id of the latest Commit within the BSR instance dennoted by registry_hostname
+  // created on the Branch.
+  string latest_commit_id = 9 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The Digest of the latest Commit pushed to the Branch.
-  buf.registry.storage.v1beta1.Digest latest_commit_digest = 11 [(buf.validate.field).required = true];
+  buf.registry.storage.v1beta1.Digest latest_commit_digest = 10 [(buf.validate.field).required = true];
 }
 
 // BranchRef is a reference to a Branch, either an id or a fully-qualified name.
@@ -75,35 +83,41 @@ message Branch {
 message BranchRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
 
+  // The fully-qualified name of a Branch within a BSR instance.
+  //
+  // A Name uniquely identifies a Branch within a BSR instance.
+  // This is used for requests when a caller only has the branch name and not the ID.
+  message Name {
+    // The name of the User or Organization that owns the Module that contains this Branch.
+    string owner = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The name of the Module that contains this Branch.
+    string module = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The name of the Branch.
+    string branch = 4 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 250
+    ];
+  }
+
+  // The hostname of the registry of the Buf Schema Registry instance that the Branch is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   oneof value {
     option (buf.validate.oneof).required = true;
-    // The id of the Branch.
-    string id = 1 [(buf.validate.field).string.uuid = true];
-    // The fully-qualified name of the Branch.
-    BranchFullName name = 2;
+    // The id of the Branch within the BSR instance as denoted by registry_hostname.
+    string id = 2 [(buf.validate.field).string.uuid = true];
+    // The fully-qualified name of the Branch within the BSR instance as denoted by registry_hostname.
+    Name name = 3;
   }
-}
-
-// The fully-qualified name of a Branch within a BSR instance.
-//
-// A BranchFullName uniquely identifies a Branch.
-// This is used for requests when a caller only has the branch name and not the ID.
-message BranchFullName {
-  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
-
-  // The name of the User or Organization that owns the Module that contains this Branch.
-  string owner = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  // The name of the Module that contains this Branch.
-  string module = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  // The name of the Branch.
-  string branch = 3 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 250
-  ];
 }

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -41,21 +41,33 @@ service BranchService {
 
 message GetBranchesRequest {
   // The Branches to request.
+  //
+  // Only Branches with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated BranchRef branch_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetBranchesResponse {
   // The retreived Branches in the same order as requested.
+  //
+  // Only Branches with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Branch branches = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetReleaseBranchesRequest {
   // The Modules to request the release Branches for.
+  //
+  // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated ModuleRef module_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetReleaseBranchesResponse {
   // The retrieved release Branches in the same order as requested.
+  //
+  // Only Branches with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Branch branches = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -78,6 +90,9 @@ message ListBranchesRequest {
   //   - If a Tag is referenced, all Branches that contain the Tag are returned.
   //   - If a VCSCommit is referenced, all Branches that contain the VCSCommit are returned.
   //   - Is a Branch is referenced, this Branch is returned.
+  //
+  // Only resources with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 
@@ -87,5 +102,8 @@ message ListBranchesResponse {
   /// If empty, there are no more pages.
   string next_page_token = 1;
   // The listed Branches.
+  //
+  // Only Branches with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Branch branches = 2;
 }

--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -29,36 +29,62 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 message Commit {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
-  // The id of the Commit.
+  // The id of the Commit within the BSR instance denoted by registry_hostname.
   string id = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
+  // The hostname of the registry of the BSR instance that the Commit is on.
+  string registry_hostname = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   // The time the Commit was pushed to the BSR.
   //
   // Commits are immutable, so there is no corresponding update_time.
-  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
-  // The id of the User or Organization that owns the Module that the Commit is associated with.
-  string owner_id = 3 [
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
+  // The id of the User or Organization within the BSR instance denoted by registry_hostname
+  // that owns the Module that the Commit is associated with.
+  string owner_id = 4 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
-  // The id of the Module that the Commit is associated with.
-  string module_id = 4 [
+  // The id of the Module within the BSR instance denoted by registry_hostname
+  // that the Commit is associated with.
+  string module_id = 5 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The digest of the Commit's contents.
   //
   // This is a digest of the digest of all files associated with the Commit.
-  buf.registry.storage.v1beta1.Digest digest = 5 [(buf.validate.field).required = true];
-  // The id of the User that created this Commit on the BSR.
-  string created_by_user_id = 6 [
+  buf.registry.storage.v1beta1.Digest digest = 6 [(buf.validate.field).required = true];
+  // The id of the User within the BSR instance denoted by registry_hostname
+  // hat created this Commit on the BSR.
+  string created_by_user_id = 7 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The SPDX license ID of the associated license, if any.
   //
   // To retrieve the specific license file, use the ContentService.
-  string spdx_license_id = 7 [(buf.validate.field).string.max_len = 255];
+  string spdx_license_id = 8 [(buf.validate.field).string.max_len = 255];
+}
+
+// CommitRef is a reference to a Commit.
+//
+// This is used in requests.
+message CommitRef {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The hostname of the registry of the Buf Schema Registry instance that the Commit is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
+  // The id of the Commit within the BSR instance as denoted by registry_hostname.
+  string id = 2 [(buf.validate.field).string.uuid = true];
 }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -71,11 +71,17 @@ message ResolveCommitsRequest {
   //   - If a Tag is referenced, this is interpreted to mean the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, this is interpreted to mean the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, this is interpreted to mean the latest Commit on the Branch.
+  //
+  // Only resources with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated ResourceRef resource_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message ResolveCommitsResponse {
   // The found Commits in the same order as requested.
+  //
+  // Only Commits with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -98,6 +104,9 @@ message ListCommitHistoryRequest {
   //   - If a Tag is referenced, history is started at the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, history is started at the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, history is started at the latest Commit on the Branch.
+  //
+  // Only resources with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
   // Only return Commits that have one or more associated Tags.
   bool has_tag = 4;
@@ -111,6 +120,9 @@ message ListCommitHistoryResponse {
   /// If empty, there are no more pages.
   string next_page_token = 1;
   // The listed Commits.
+  //
+  // Only Commits with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Commit commits = 2;
 }
 
@@ -189,6 +201,9 @@ message CreateCommitsResponse {
   //
   // If the digest was found for an pre-existing Commit, this pre-existing Commit will be returned
   // instead of a new Commit being created.
+  //
+  // Only Commits with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -205,6 +220,9 @@ message GetFileNodesRequest {
     //   - If a Tag is referenced, files are returned from the Commit associated with the Tag.
     //   - If a VCSCommit is referenced, files are returned from the Commit associated with the VCSCommit.
     //   - Is a Branch is referenced, files are returned from the latest Commit on the Branch.
+    //
+    // Only resources with registry_hostnames equal to the hostname of the BSR instance you are
+    // calling can be referenced, other registry_hostnames will result in an error.
     ResourceRef resource_ref = 1 [(buf.validate.field).required = true];
     // Specific file paths to retrieve.
     //
@@ -232,7 +250,12 @@ message GetFileNodesRequest {
 message GetFileNodesResponse {
   // A single set of FileNodes and their associated commits.
   message Value {
+    // The FileNodes for the Commit.
     repeated buf.registry.storage.v1beta1.FileNode file_nodes = 1 [(buf.validate.field).repeated.min_items = 1];
+    // The Commit associated with the FileNodes.
+
+    // Only Commits with registry_hostnames equal to the hostname of the BSR instance you are
+    // calling will be returned.
     Commit commit = 2 [(buf.validate.field).required = true];
   }
   // The returned File sets in the same order as requested.

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -26,46 +26,53 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 message Module {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
-  // The id of the Module.
+  // The id of the Module within the BSR instance denoted by registry_hostname.
   string id = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
+  // The hostname of the registry of the Buf Schema Registry instance that the Module is on.
+  string registry_hostname = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   // The time the Module was created on the BSR.
-  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
   // The last time the Module was updated on the BSR.
-  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp update_time = 4 [(buf.validate.field).required = true];
   // The name of the Module.
   //
   // Unique within a given User or Organization.
-  string name = 4 [
+  string name = 5 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 255
   ];
-  // The id of the User or Organization that owns the Module.
-  string owner_id = 5 [
+  // The id of the User or Organization within the BSR instance denoted by registry_hostname
+  // that owns the Module.
+  string owner_id = 6 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The Module's visibility, either public or private.
-  ModuleVisibility visibility = 6 [
+  ModuleVisibility visibility = 7 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
   // The Module state, either active or deprecated.
-  ModuleState state = 7 [
+  ModuleState state = 8 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
   // The configurable description of the Module.
-  string description = 8 [(buf.validate.field).string.max_len = 350];
+  string description = 9 [(buf.validate.field).string.max_len = 350];
   // The configurable URL in the description of the Module,
-  string url = 9 [
+  string url = 10 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 1023
   ];
-  // The id of the Branch which releases are generated from.
-  string release_branch_id = 10 [
+  // The id of the Branch within the BSR instance denoted by registry_hostname
+  // which releases are generated from.
+  string release_branch_id = 11 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
@@ -96,30 +103,36 @@ enum ModuleState {
 message ModuleRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
 
+  // The fully-qualified name of a Module within a BSR instance.
+  //
+  // A Name uniquely identifies a Module within a BSR instance.
+  // This is used for requests when a caller only has the module name and not the ID.
+  message Name {
+    // The name of the owner of the Module, either a User or Organization.
+    string owner = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The name of the Module.
+    string module = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+  }
+
+  // The hostname of the registry of the Buf Schema Registry instance that the Module is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the Module.
-    string id = 1 [(buf.validate.field).string.uuid = true];
+    string id = 2 [(buf.validate.field).string.uuid = true];
     // The fully-qualified name of the Module.
-    ModuleFullName name = 2;
+    Name name = 3;
   }
-}
-
-// The fully-qualified name of a Module within a BSR instance.
-//
-// A ModuleFullName uniquely identifies a Module.
-// This is used for requests when a caller only has the module name and not the ID.
-message ModuleFullName {
-  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
-
-  // The name of the owner of the Module, either a User or Organization.
-  string owner = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  // The name of the Module.
-  string module = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
 }

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -51,11 +51,17 @@ service ModuleService {
 
 message GetModulesRequest {
   // The Modules to request.
+  //
+  // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated ModuleRef module_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetModulesResponse {
   // The retrieved Modules in the same order as requested.
+  //
+  // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Module modules = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -72,6 +78,9 @@ message ListModulesRequest {
   //
   // If empty, all Modules for all owners are listed, but this functionality
   // is only available for Users with the UserServerRole of USER_SERVER_ROLE_ADMIN.
+  //
+  // Only owners with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated buf.registry.owner.v1beta1.OwnerRef owner_refs = 3;
 }
 
@@ -81,6 +90,9 @@ message ListModulesResponse {
   /// If empty, there are no more pages.
   string next_page_token = 1 [(buf.validate.field).string.max_len = 255];
   // The listed Modules.
+  //
+  // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Module modules = 2;
 }
 
@@ -88,6 +100,9 @@ message CreateModulesRequest {
   // An individual request to create a Module.
   message Value {
     // The User or Organization to create the Module under.
+    //
+    // Only owners with registry_hostnames equal to the hostname of the BSR instance you are
+    // calling will be returned.
     buf.registry.owner.v1beta1.OwnerRef owner_ref = 1 [(buf.validate.field).required = true];
     // The name of the Module.
     string name = 2 [
@@ -117,6 +132,9 @@ message CreateModulesRequest {
 
 message CreateModulesResponse {
   // The created Modules in the same order as given on the request.
+  //
+  // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Module modules = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -124,6 +142,9 @@ message UpdateModulesRequest {
   // An individual request to update a Module.
   message Value {
     // The Module to update.
+    //
+    // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+    // calling can be referenced, other registry_hostnames will result in an error.
     ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The module's visibility.
     optional ModuleVisibility visibility = 3 [(buf.validate.field).enum.defined_only = true];
@@ -139,10 +160,12 @@ message UpdateModulesRequest {
     oneof release_branch_ref {
       // The id of the release Branch of the Module.
       //
+      // This ID must be an ID of a Branch tied to the Module as denoted by module_ref.
       // This Branch must already exist.
       string release_branch_id = 7 [(buf.validate.field).string.uuid = true];
       // The name of the release Branch of the Module.
       //
+      // This name must be the name of a Branch tied to the Module as denoted by module_ref.
       // This Branch must already exist.
       string release_branch_name = 8 [(buf.validate.field).string.max_len = 250];
     }
@@ -153,11 +176,17 @@ message UpdateModulesRequest {
 
 message UpdateModulesResponse {
   // The updated Modules in the same order as given on the request.
+  //
+  // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Module modules = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message DeleteModulesRequest {
   // The Modules to delete.
+  //
+  // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated ModuleRef module_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -38,52 +38,67 @@ message ResourceRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
   option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;
 
-  oneof ref {
-    string id = 1;
-    ResourceFullName name = 2;
+  // The fully-qualified name component of a ResourceRef.
+  //
+  // See the documentation on ResourceRef for more details.
+  //
+  // The following semantics are applied:
+  //   - If the child oneof is not specified, the name is interpreted to reference a Module.
+  //   - If branch_name is specified, the name is interpreted to reference a Branch.
+  //   - If tag_name is specified, the name is interpreted to reference a Tag.
+  //   - If vcs_commit_hash is specified, the name is interpeted to reference a VCSCommit.
+  //   - If ref is specified, it is interpreted to be either an id or name.
+  //     - If an id, this is equivalent to setting the id field on ResourceRef. However,
+  //       backends can choose to validate that the owner and module fields match the resource
+  //       referenced, as additional validation.
+  //     - If a name, this is interpreted to be either a Branch name, Tag name,
+  //       or VCSCommit hash.
+  //     - If there is a conflict between names across resources (for example, there is a
+  //       Branch and Tag with the same name), the following order of precedence is applied:
+  //       - Commit
+  //       - VCSCommit
+  //       - Tag
+  //       - Branch
+  //
+  // Names can only be used in requests, and only for read-only RPCs, that is
+  // you should not use an arbitrary reference when modifying a specific resource.
+  message Name {
+    // The name of the User or Organization that owns the resource.
+    string owner = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The name of the Module that either contains the resource or is the resource (that is,
+    // the resource referenced is this Module).
+    string module = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    oneof child {
+      // The name of the Branch.
+      string branch_name = 3 [(buf.validate.field).string.max_len = 250];
+      // The name of the Tag.
+      string tag_name = 4 [(buf.validate.field).string.max_len = 250];
+      // hash of the VCSCommit.
+      string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
+      // The untyped reference. See the documentation on Name for more details.
+      string ref = 6;
+    }
   }
-}
 
-// The fully-qualified name component of a ResourceRef.
-//
-// See the documentation on ResourceRef for more details.
-//
-// The following semantics are applied:
-//   - If the child oneof is not specified, the name is interpreted to reference a Module.
-//   - If branch_name is specified, the name is interpreted to reference a Branch.
-//   - If tag_name is specified, the name is interpreted to reference a Tag.
-//   - If vcs_commit_hash is specified, the name is interpeted to reference a VCSCommit.
-//   - If ref is specified, it is interpreted to be either an id or name.
-//     - If an id, this is equivalent to setting the id field on ResourceRef. However,
-//       backends can choose to validate that the owner and module fields match the resource
-//       referenced, as additional validation.
-//     - If a name, this is interpreted to be either a Branch name, Tag name,
-//       or VCSCommit hash.
-//     - If there is a conflict between names across resources (for example, there is a
-//       Branch and Tag with the same name), the following order of precedence is applied:
-//       - Commit
-//       - VCSCommit
-//       - Tag
-//       - Branch
-//
-// ResourceFullNames can only be used in requests, and only for read-only RPCs, that is
-// you should not use an arbitrary reference when modifying a specific resource.
-message ResourceFullName {
-  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
-  option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;
-
-  string owner = 1 [
+  // The hostname of the registry of the Buf Schema Registry instance that the reference is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.hostname = true
   ];
-  string module = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  oneof child {
-    string branch_name = 3 [(buf.validate.field).string.max_len = 250];
-    string tag_name = 4 [(buf.validate.field).string.max_len = 250];
-    string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
-    string ref = 6;
+  oneof value {
+    option (buf.validate.oneof).required = true;
+    // The ID of the resource within the BSR instance as denoted by registry_hostname.
+    string id = 2 [(buf.validate.field).string.uuid = true];
+    // The fully-qualified name of the resource within the BSR instance as denoted by registry_hostname.
+    Name name = 3;
   }
 }

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -29,44 +29,53 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 message Tag {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
-  // The id of the Tag.
+  // The id of the Tag within the BSR instance denoted by registry_hostname.
   string id = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
+  // The hostname of the registry of the BSR instance that the Tag is on.
+  string registry_hostname = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   // The time the Tag was created on the BSR.
-  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
   // The last time the Tag was updated on the BSR.
   //
   // Currently, Tags are immutable, but this may change in the near future.
   // TODO: is this true?
-  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp update_time = 4 [(buf.validate.field).required = true];
   // The name of the Tag.
   //
   // Unique within a given Module.
-  string name = 4 [
+  string name = 6 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250
   ];
-  // The id of the User or Organization that owns the Module that the Tag is associated with.
-  string owner_id = 5 [
+  // The id of the User or Organization within the BSR instance denoted by registry_hostname
+  // that owns the Module that the Tag is associated with.
+  string owner_id = 7 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
-  // The id of the Module that the Tag is associated with.
-  string module_id = 6 [
+  // The id of the Module within the BSR instance denoted by registry_hostname
+  // that the Tag is associated with.
+  string module_id = 8 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
-  // The id of the Commit associated with the Tag.
-  string commit_id = 7 [
+  // The id of the Commit within the BSR instance denoted by registry_hostname
+  // associated with the Tag.
+  string commit_id = 9 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The Digest of the Commit associated with the Tag.
-  buf.registry.storage.v1beta1.Digest commit_digest = 8 [(buf.validate.field).required = true];
-  // The id of the User that last updated this Tag on the BSR.
-  string updated_by_user_id = 9 [
+  buf.registry.storage.v1beta1.Digest commit_digest = 10 [(buf.validate.field).required = true];
+  // The id of the User within the BSR instance denoted by registry_hostname
+  // that last updated this Tag on the BSR.
+  string updated_by_user_id = 11 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
@@ -78,35 +87,41 @@ message Tag {
 message TagRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
 
+  // The fully-qualified name of a Tag within a BSR instance.
+  //
+  // A Name uniquely identifies a Tag within a BSR instance.
+  // This is used for requests when a caller only has the tag name and not the ID.
+  message Name {
+    // The name of the owner of the Module that contains the Tag, either a User or Organization.
+    string owner = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The name of the Module that contains the Tag, either a User or Organization.
+    string module = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The Tag name.
+    string tag = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 250
+    ];
+  }
+
+  // The hostname of the registry of the Buf Schema Registry instance that the Tag is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the Tag.
-    string id = 1 [(buf.validate.field).string.uuid = true];
+    string id = 2 [(buf.validate.field).string.uuid = true];
     // The fully-qualified name of the Tag.
-    TagFullName name = 2;
+    Name name = 3;
   }
-}
-
-// The fully-qualified name of a Tag within a BSR instance.
-//
-// A TagFullName uniquely identifies a Tag.
-// This is used for requests when a caller only has the tag name and not the ID.
-message TagFullName {
-  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
-
-  // The name of the owner of the Module that contains the Tag, either a User or Organization.
-  string owner = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  // The name of the Module that contains the Tag, either a User or Organization.
-  string module = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  // The Tag name.
-  string tag = 3 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 250
-  ];
 }

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -45,11 +45,17 @@ service TagService {
 
 message GetTagsRequest {
   // The Tags to request.
+  //
+  // Only Tags with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated TagRef tag_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetTagsResponse {
   // The retrieved Tags in the same order as requested.
+  //
+  // Only Tags with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -72,6 +78,9 @@ message ListTagsRequest {
   //   - If a Tag is referenced, this Tag is returned.
   //   - If a VCSCommit is referenced, all Tags for commits that the VCSCommit is associated with are returned.
   //   - Is a Branch is referenced, all Tags for Commits on the Branch are returned.
+  //
+  // Only resources with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 
@@ -81,6 +90,9 @@ message ListTagsResponse {
   /// If empty, there are no more pages.
   string next_page_token = 1;
   // The listed Tags.
+  //
+  // Only Tags with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Tag tags = 2;
 }
 
@@ -88,13 +100,18 @@ message CreateTagsRequest {
   // An individual request to create a Tag.
   message Value {
     // The Module to create the Tag under.
+    //
+    // Only Modules with registry_hostnames equal to the hostname of the BSR instance you are
+    // calling can be referenced, other registry_hostnames will result in an error.
     ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The Tag name.
     string name = 2 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.max_len = 250
     ];
-    // The id of the Commit associated with the Tag.
+    // The id of the Commit associated with the Tag
+    //
+    // This Commit must be associated with the Module as denoted by module_ref.
     string commit_id = 3 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.uuid = true
@@ -106,11 +123,17 @@ message CreateTagsRequest {
 
 message CreateTagsResponse {
   // The created Tags in the same order as given on the request.
+  //
+  // Only Tags with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message DeleteTagsRequest {
   // The Tags to delete.
+  //
+  // Only Tags with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated TagRef tag_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -29,69 +29,77 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 message VCSCommit {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
-  // The id of the VCSCommit.
+  // The id of the VCSCommit within the BSR instnace denoted by registry_hostname.
   string id = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
+  // The hostname of the registry of the BSR instance that the VCSCommit is on.
+  string registry_hostname = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   // The time the VCSCommit was created on the BSR.
-  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
   // The last time the VCSCommit was updated on the BSR.
   //
   // Currently, VCSCommits are immutable, but this may change in the near future.
   // TODO: is this true?
-  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp update_time = 4 [(buf.validate.field).required = true];
   // The hash of the VCSCommit.
   //
   // VCS-specific.
   // Unique within a given Module.
-  string hash = 4 [
+  string hash = 5 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 255
   ];
-  // The id of the User or Organization that owns the Module that the VCSCommit is associated with.
-  string owner_id = 5 [
+  // The id of the User or Organization within the BSR instance denoted by registry_hostname
+  // that owns the Module that the VCSCommit is associated with.
+  string owner_id = 6 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
-  // The id of the Module that the VCSCommit is associated with.
-  string module_id = 6 [
+  // The id of the Module within the BSR instance denoted by registry_hostname
+  // that the VCSCommit is associated with.
+  string module_id = 7 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The type of VCS.
-  VCSType type = 7 [
+  VCSType type = 8 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
-  // The id of the Commit associated with the VCSCommit.
-  string commit_id = 8 [
+  // The id of the Commit within the BSR instance denoted by registry_hostname
+  // associated with the VCSCommit.
+  string commit_id = 9 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The Digest of the Commit associated with the VCSCommit.
-  buf.registry.storage.v1beta1.Digest commit_digest = 9 [(buf.validate.field).required = true];
+  buf.registry.storage.v1beta1.Digest commit_digest = 10 [(buf.validate.field).required = true];
   // The URL of of the repository on the VCS.
-  string vcs_repository_url = 10 [
+  string vcs_repository_url = 11 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uri = true
   ];
   // The name of the author of the VCSCommit.
   //
   // VCS-specific: not associated with the name of Users on the BSR, for example.
-  string author_name = 11;
+  string author_name = 12;
   // The email of the author of the VCSCommit.
   //
   // VCS-specific: not associated with the Users on the BSR, for example.
-  string author_email = 12;
+  string author_email = 13;
   // The name of the committer of the VCSCommit.
   //
   // VCS-specific: not associated with the name of Users on the BSR, for example.
-  string committer_name = 13;
+  string committer_name = 14;
   // The email of the committer of the VCSCommit.
   //
   // VCS-specific: not associated with the Users on the BSR, for example.
-  string committer_email = 14;
+  string committer_email = 15;
 }
 
 // The VCS type, currently only git.
@@ -107,35 +115,41 @@ enum VCSType {
 message VCSCommitRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
 
+  // The fully-qualified name of a VCSCommit within a BSR instance.
+  //
+  // A Name uniquely identifies a VCSCommit within a BSR instance.
+  // This is used for requests when a caller only has the VCSCommit hash and not the ID.
+  message Name {
+    // The name of the owner of the Module that contains the VCSCommit, either a user or organization.
+    string owner = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The name of the Module that contains the VCSCommit.
+    string module = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The hash of the VCSCommit.
+    string hash = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+  }
+
+  // The hostname of the registry of the Buf Schema Registry instance that the VCSCommit is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   oneof value {
     option (buf.validate.oneof).required = true;
-    // The id of the VCSCommit.
-    string id = 1 [(buf.validate.field).string.uuid = true];
-    // The fully-qualified name of the VCSCommit.
-    VCSCommitFullName name = 2;
+    // The id of the VCSCommit within the BSR instance as denoted by registry_hostname.
+    string id = 2 [(buf.validate.field).string.uuid = true];
+    // The fully-qualified name of the VCSCommit within the BSR instance as denoted by registry_hostname.
+    Name name = 3;
   }
-}
-
-// The fully-qualified name of a VCSCommit within a BSR instance.
-//
-// A VCSCommitFullName uniquely identifies a VCSCommit.
-// This is used for requests when a caller only has the VCSCommit hash and not the ID.
-message VCSCommitFullName {
-  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
-
-  // The name of the owner of the Module that contains the VCSCommit, either a user or organization.
-  string owner = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  // The name of the Module that contains the VCSCommit.
-  string module = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
-  // The hash of the VCSCommit.
-  string hash = 3 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
-  ];
 }

--- a/buf/registry/module/v1beta1/vcs_commit_service.proto
+++ b/buf/registry/module/v1beta1/vcs_commit_service.proto
@@ -36,11 +36,17 @@ service VCSCommitService {
 
 message GetVCSCommitsRequest {
   // The VCSCommits to request.
+  //
+  // Only VCSCommits with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated VCSCommitRef vcs_commit_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetVCSCommitsResponse {
   // The retrieved VCSCommits in the same order as requested.
+  //
+  // Only VCSCommits with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated VCSCommit vcs_commits = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -64,6 +70,9 @@ message ListVCSCommitsRequest {
   //   - If a Tag is referenced, all VCSCommits for the Commit associated with the Tag are returned.
   //   - If a VCSCommit is referenced, this VCSCommit is returned.
   //   - Is a Branch is referenced, all VCSCommits associated with Commits on the Branch are returned.
+  //
+  // Only resources with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 
@@ -73,5 +82,8 @@ message ListVCSCommitsResponse {
   /// If empty, there are no more pages.
   string next_page_token = 1;
   // The listed VCSCommits.
+  //
+  // Only VCSCommits with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated VCSCommit vcs_commits = 2;
 }

--- a/buf/registry/owner/v1beta1/organization.proto
+++ b/buf/registry/owner/v1beta1/organization.proto
@@ -24,35 +24,40 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 
 // Organization is an organization on the BSR.
 //
-// A name uniquely identifies an Organization, however name is mutable.
+// A name uniquely identifies an Organization within a BSR instance, however name is mutable.
 message Organization {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
-  // The id for the Organization.
+  // The id for the Organization within the BSR instance denoted by registry_hostname.
   string id = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
+  // The hostname of the registry of the BSR instance that the Organization is on.
+  string registry_hostname = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   // The time the Organization was created.
-  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
   // The last time the Organization was updated.
-  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp update_time = 4 [(buf.validate.field).required = true];
   // The name of the Organization.
   //
-  // A name uniquely identifies an Organization, however name is mutable.
-  string name = 4 [
+  // A name uniquely identifies an Organization within a BSR instance, however name is mutable.
+  string name = 5 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 255
   ];
   // The configurable description of the Organization.
-  string description = 5 [(buf.validate.field).string.max_len = 350];
+  string description = 6 [(buf.validate.field).string.max_len = 350];
   // The configurable URL that represents the homepage for an Organization.
-  string url = 6 [
+  string url = 7 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 1023
   ];
   // The verification status of the Organization.
-  OrganizationVerificationStatus verification_status = 7 [
+  OrganizationVerificationStatus verification_status = 8 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
@@ -75,12 +80,20 @@ enum OrganizationVerificationStatus {
 message OrganizationRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
 
+  // The hostname of the registry of the Buf Schema Registry instance that the Organization is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the Organization.
-    string id = 1 [(buf.validate.field).string.uuid = true];
+    string id = 2 [(buf.validate.field).string.uuid = true];
     // The name of the Organization.
-    string name = 2 [(buf.validate.field).string = {
+    string name = 3 [(buf.validate.field).string = {
       min_len: 1;
       max_len: 255;
     }];

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -48,11 +48,17 @@ service OrganizationService {
 
 message GetOrganizationsRequest {
   // The Organizations to request.
+  //
+  // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated OrganizationRef organization_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetOrganizationsResponse {
   // The retrieved Organizations in the same order as requested.
+  //
+  // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Organization organizations = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -69,6 +75,9 @@ message ListOrganizationsRequest {
   //
   // If this is empty, all Organizations are listed, but this functionality
   // is only available for Users with the UserServerRole of USER_SERVER_ROLE_ADMIN.
+  //
+  // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated UserRef user_refs = 3;
 }
 
@@ -78,6 +87,9 @@ message ListOrganizationsResponse {
   /// If empty, there are no more pages.
   string next_page_token = 1 [(buf.validate.field).string.max_len = 255];
   // The listed Organizations.
+  //
+  // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Organization organizations = 2;
 }
 
@@ -107,6 +119,9 @@ message CreateOrganizationsRequest {
 
 message CreateOrganizationsResponse {
   // The created Organizations in the same order as given on the request.
+  //
+  // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Organization organizations = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -114,6 +129,9 @@ message UpdateOrganizationsRequest {
   // An individual request to update an Organization.
   message Value {
     // The organization to update.
+    //
+    // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+    // calling can be referenced, other registry_hostnames will result in an error.
     OrganizationRef organization_ref = 1 [(buf.validate.field).required = true];
     // The configurable description of the Organization.
     optional string description = 2 [(buf.validate.field).string.max_len = 350];
@@ -131,11 +149,17 @@ message UpdateOrganizationsRequest {
 
 message UpdateOrganizationsResponse {
   // The updated Organizations in the same order as given on the request.
+  //
+  // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Organization organizations = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message DeleteOrganizationsRequest {
   // The Organizations to delete.
+  //
+  // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated OrganizationRef organization_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/buf/registry/owner/v1beta1/owner.proto
+++ b/buf/registry/owner/v1beta1/owner.proto
@@ -42,12 +42,20 @@ message Owner {
 message OwnerRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
 
+  // The hostname of the registry of the Buf Schema Registry instance that the User or Organization is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the User or Organization.
-    string id = 1 [(buf.validate.field).string.uuid = true];
+    string id = 2 [(buf.validate.field).string.uuid = true];
     // The name of the User or Organization.
-    string name = 2 [(buf.validate.field).string = {
+    string name = 3 [(buf.validate.field).string = {
       min_len: 1;
       max_len: 255;
     }];

--- a/buf/registry/owner/v1beta1/owner_service.proto
+++ b/buf/registry/owner/v1beta1/owner_service.proto
@@ -33,10 +33,16 @@ service OwnerService {
 
 message GetOwnersRequest {
   // The Users or Organizations to request.
+  //
+  // Only Users or Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated OwnerRef owner_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetOwnersResponse {
   // The retreived Users or Organizations in the same order as requested.
+  //
+  // Only Users or Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated Owner owners = 1 [(buf.validate.field).repeated.min_items = 1];
 }

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -24,7 +24,7 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 
 // A user on the BSR.
 //
-// A name uniquely identifies a User, however name is mutable.
+// A name uniquely identifies a User within a BSR instance, however name is mutable.
 message User {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
@@ -33,41 +33,46 @@ message User {
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
+  // The hostname of the registry of the BSR instance that the User is on.
+  string registry_hostname = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   // The time the User was created.
-  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
   // The last time the User was updated.
-  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  google.protobuf.Timestamp update_time = 4 [(buf.validate.field).required = true];
   // The name of the User.
   //
-  // A name uniquely identifies a User, however name is mutable.
-  string name = 4 [
+  // A name uniquely identifies a User within a BSR instance, however name is mutable.
+  string name = 5 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 255
   ];
   // The type of the User.
-  UserType type = 5 [
+  UserType type = 6 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
   // The state of the User.
-  UserState state = 6 [
+  UserState state = 7 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
   // The role that the User has at the BSR instance level.
-  UserServerRole server_role = 7 [
+  UserServerRole server_role = 8 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
   // The configurable description of the User.
-  string description = 8 [(buf.validate.field).string.max_len = 350];
+  string description = 9 [(buf.validate.field).string.max_len = 350];
   // The configurable URL that represents the homepage for a User.
-  string url = 9 [
+  string url = 10 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 1023
   ];
   // The verification status of the User.
-  UserVerificationStatus verification_status = 10 [
+  UserVerificationStatus verification_status = 11 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
@@ -113,12 +118,20 @@ enum UserVerificationStatus {
 message UserRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
 
+  // The hostname of the registry of the Buf Schema Registry instance that the User is on.
+  //
+  // In most circumstances, this must match the hostname of the instance you are calling via the API.
+  // Where there are exceptions to this, this is specifically noted in the top-level request message.
+  string registry_hostname = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the User.
-    string id = 1 [(buf.validate.field).string.uuid = true];
+    string id = 2 [(buf.validate.field).string.uuid = true];
     // The name of the User.
-    string name = 2 [(buf.validate.field).string = {
+    string name = 3 [(buf.validate.field).string = {
       min_len: 1;
       max_len: 255;
     }];

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -48,11 +48,17 @@ service UserService {
 
 message GetUsersRequest {
   // The Users to request.
+  //
+  // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated UserRef user_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message GetUsersResponse {
   // The retreived Users in the same order as requested.
+  //
+  // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated User users = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -69,6 +75,9 @@ message ListUsersRequest {
   //
   // If this is empty, all Users for all Organizations are listed, but this functionality
   // is only available for Users with the UserServerRole of USER_SERVER_ROLE_ADMIN.
+  //
+  // Only Organizations with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated OrganizationRef organization_refs = 3;
 }
 
@@ -78,6 +87,9 @@ message ListUsersResponse {
   /// If empty, there are no more pages.
   string next_page_token = 1 [(buf.validate.field).string.max_len = 255];
   // The list of Users.
+  //
+  // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated User users = 2;
 }
 
@@ -115,6 +127,9 @@ message CreateUsersRequest {
 
 message CreateUsersResponse {
   // The created Users in the same order as given on the request.
+  //
+  // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated User users = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -122,6 +137,9 @@ message UpdateUsersRequest {
   // An individual request to update a User.
   message Value {
     // The User to update.
+    //
+    // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+    // calling can be referenced, other registry_hostnames will result in an error.
     UserRef user_ref = 1 [(buf.validate.field).required = true];
     // The state of the User.
     optional UserState state = 2 [(buf.validate.field).enum.defined_only = true];
@@ -143,11 +161,17 @@ message UpdateUsersRequest {
 
 message UpdateUsersResponse {
   // The updated Users in the same order as given on the request.
+  //
+  // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling will be returned.
   repeated User users = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message DeleteUsersRequest {
   // The Users to delete.
+  //
+  // Only Users with registry_hostnames equal to the hostname of the BSR instance you are
+  // calling can be referenced, other registry_hostnames will result in an error.
   repeated UserRef user_refs = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 


### PR DESCRIPTION
This PR makes federation a first-class citizen by effectively adding the concept of `registry_hostname` to all resources. `registry_hostname` is a rename of what we currently call `remote` within our codebases.

Motivation:

- There's work that I want to do to no longer send the full `buf.yaml` over the wire to the backend - we're defining the `buf.yaml` to not make up part of a `Module`, and once you do this, it becomes somewhat easy to deconstruct what you send over the wire. Even moreso, I'd argue this is desirable - the backend should not have to concern itself with `buf.yamls`, their layout, or their parsing, as they will not make up part of a `Commit`'s digest.
- To do such deconstruction, you need some message that makes up what we call, `ModulePin` right now - a `Commit` and its associated `Digest`. However, both historically and likely soon-to-be in the future, we've allowed for federation, meaning that it's possible that some `Commits' may lie outside of the given BSR instance you are calling via the API.
- You therefore need a way to represent the registry of a `Commit` both in the request, and returned `Commit` objects.
- It was pointed out that a shortcoming of this API is that federation wasn't accounted for, and this is a use case we currently have for legacy reasons, regardless of what we want going forward (which may be federation as well).

The path to this PR:

- First, you realize you need to add a `registry_hostname` to `Commit`. Easy enough.
- Next, you realize that you need to qualify all IDs on the `Commit` as scoped to the BSR instance as denoted by `registry_hostname`. For example, `module_id` is now the ID of the `Module` on the BSR instance as denoted by `registry_hostname`.
- Inevitably, this means you need `registry_hostnames` the whole way down - `Modules, Users, Organizations` specifically.
- At this point, for consistency and because we're letting half of our resources account for federation, you realize you likely want `registry_hostname` on `Tag, VCSCommit, Branch` as well.

What this PR does:

- Adds `registry_hostname` to all resources.
- Clarifies in the comments that IDs are scoped to the given `registry_hostname`.
- Refactors `.*Refs`: `.*FullNames` are moved inside `Refs` as a nested message `Name` (this is likely a nice cleanup anyways, as we only use `FullNames` inside of `Refs` anyways at the API level). Since both `id` and `name` must be scoped to a `registry_hostname`, it is not desirable to repeat `registry_hostname` on both a theoretical `id` wrapper, and `.*FullName`, hence now defining `.*FullName` as a nested message that requires other data in the encapsulating message.
- Adds a `CommitRef` that will be used in the `CommitService` on `CreateCommits` in a future PR.
- Updates basically every comment to say that `registry_hostnames` need to match the BSR instance you are invoking for now. As this changes, we can relax these comments.

To be honest, I don't like it. It feels very messy. But I don't know if there's a better solution here, assuming we need to account for federation.

Let's discuss this on Monday @rodaine @jhump @Alfus @pkwarren @jchadwick-buf @saquibmian @doriable @mfridman and come to a conclusion.