### PR TITLE
Add max limit for refs or values in requests

### DIFF
--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -41,7 +41,10 @@ service BranchService {
 
 message GetBranchesRequest {
   // The Branches to request.
-  repeated BranchRef branch_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated BranchRef branch_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetBranchesResponse {
@@ -51,7 +54,10 @@ message GetBranchesResponse {
 
 message GetReleaseBranchesRequest {
   // The Modules to request the release Branches for.
-  repeated ModuleRef module_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated ModuleRef module_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetReleaseBranchesResponse {

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -78,7 +78,10 @@ message ResolveCommitsRequest {
   //   - If a Tag is referenced, this is interpreted to mean the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, this is interpreted to mean the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, this is interpreted to mean the latest Commit on the Branch.
-  repeated ResourceRef resource_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated ResourceRef resource_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message ResolveCommitsResponse {
@@ -264,7 +267,10 @@ message GetCommitNodesRequest {
     bool allow_paths_not_exist = 3;
   }
   // The File sets to request.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetCommitNodesResponse {
@@ -290,7 +296,10 @@ message GetCommitNodesResponse {
 
 message GetBlobsRequest {
   // The digests to retrieve Blobs for.
-  repeated buf.registry.storage.v1beta1.Digest digests = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated buf.registry.storage.v1beta1.Digest digests = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetBlobsResponse {
@@ -300,7 +309,10 @@ message GetBlobsResponse {
 
 message GetMissingBlobDigestsRequest {
   // The digests to see if we have Blobs for.
-  repeated buf.registry.storage.v1beta1.Digest digests = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated buf.registry.storage.v1beta1.Digest digests = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetMissingBlobDigestsResponse {

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -51,7 +51,10 @@ service ModuleService {
 
 message GetModulesRequest {
   // The Modules to request.
-  repeated ModuleRef module_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated ModuleRef module_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetModulesResponse {
@@ -112,7 +115,10 @@ message CreateModulesRequest {
     string release_branch_name = 6 [(buf.validate.field).string.max_len = 250];
   }
   // The Modules to create.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message CreateModulesResponse {
@@ -150,7 +156,10 @@ message UpdateModulesRequest {
     }
   }
   // The Modules to update.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message UpdateModulesResponse {
@@ -160,7 +169,10 @@ message UpdateModulesResponse {
 
 message DeleteModulesRequest {
   // The Modules to delete.
-  repeated ModuleRef module_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated ModuleRef module_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message DeleteModulesResponse {}

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -45,7 +45,10 @@ service TagService {
 
 message GetTagsRequest {
   // The Tags to request.
-  repeated TagRef tag_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated TagRef tag_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetTagsResponse {
@@ -101,7 +104,10 @@ message CreateTagsRequest {
     ];
   }
   // The Tags to create.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message CreateTagsResponse {
@@ -111,7 +117,10 @@ message CreateTagsResponse {
 
 message DeleteTagsRequest {
   // The Tags to delete.
-  repeated TagRef tag_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated TagRef tag_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message DeleteTagsResponse {}

--- a/buf/registry/module/v1beta1/vcs_commit_service.proto
+++ b/buf/registry/module/v1beta1/vcs_commit_service.proto
@@ -36,7 +36,10 @@ service VCSCommitService {
 
 message GetVCSCommitsRequest {
   // The VCSCommits to request.
-  repeated VCSCommitRef vcs_commit_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated VCSCommitRef vcs_commit_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetVCSCommitsResponse {

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -48,7 +48,10 @@ service OrganizationService {
 
 message GetOrganizationsRequest {
   // The Organizations to request.
-  repeated OrganizationRef organization_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated OrganizationRef organization_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetOrganizationsResponse {
@@ -102,7 +105,10 @@ message CreateOrganizationsRequest {
     OrganizationVerificationStatus verification_status = 4 [(buf.validate.field).enum.defined_only = true];
   }
   // The Organizations to create.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message CreateOrganizationsResponse {
@@ -126,7 +132,10 @@ message UpdateOrganizationsRequest {
     optional OrganizationVerificationStatus verification_status = 4 [(buf.validate.field).enum.defined_only = true];
   }
   // The Organizations to update.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message UpdateOrganizationsResponse {
@@ -136,7 +145,10 @@ message UpdateOrganizationsResponse {
 
 message DeleteOrganizationsRequest {
   // The Organizations to delete.
-  repeated OrganizationRef organization_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated OrganizationRef organization_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message DeleteOrganizationsResponse {}

--- a/buf/registry/owner/v1beta1/owner_service.proto
+++ b/buf/registry/owner/v1beta1/owner_service.proto
@@ -33,7 +33,10 @@ service OwnerService {
 
 message GetOwnersRequest {
   // The Users or Organizations to request.
-  repeated OwnerRef owner_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated OwnerRef owner_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetOwnersResponse {

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -48,7 +48,10 @@ service UserService {
 
 message GetUsersRequest {
   // The Users to request.
-  repeated UserRef user_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated UserRef user_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetUsersResponse {
@@ -110,7 +113,10 @@ message CreateUsersRequest {
     UserVerificationStatus verification_status = 6 [(buf.validate.field).enum.defined_only = true];
   }
   // The Users to create.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message CreateUsersResponse {
@@ -138,7 +144,10 @@ message UpdateUsersRequest {
     optional UserVerificationStatus verification_status = 6 [(buf.validate.field).enum.defined_only = true];
   }
   // The Users to update.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message UpdateUsersResponse {
@@ -148,7 +157,10 @@ message UpdateUsersResponse {
 
 message DeleteUsersRequest {
   // The Users to delete.
-  repeated UserRef user_refs = 1 [(buf.validate.field).repeated.min_items = 1];
+  repeated UserRef user_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message DeleteUsersResponse {}


### PR DESCRIPTION
This PR adds `max_items` to `GetOwnersRequest`.

I think we should avoid unbounded repeated refs and have sane limits. If a client needs to resolve >250 IDs or names, they can hit the endpoint multiple times.

Although it's not a list endpoint, used 250 for parity.