### PR TITLE
Validation for paths

### DIFF
--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -252,7 +252,7 @@ message GetCommitNodesRequest {
     // The separator "/" must be used.
     repeated string paths = 2 [(buf.validate.field).repeated.items = {
       string: {
-        max_len: 1000
+        max_len: 4096
         not_contains: "\\"
         pattern: "^([^/.][^/]?|[^/][^/.]|[^/]{3,})(/([^/.][^/]?|[^/][^/.]|[^/]{3,}))*$"
       }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -250,10 +250,12 @@ message GetCommitNodesRequest {
     //
     // The path must be relative, and connect contain any "." or ".." components
     // The separator "/" must be used.
-    //
-    // TODO: Can we encode the above requirements via validation?
     repeated string paths = 2 [(buf.validate.field).repeated.items = {
-      string: {max_len: 4096}
+      string: {
+        max_len: 1000
+        not_contains: "\\"
+        pattern: "^([^/.][^/]?|[^/][^/.]|[^/]{3,})(/([^/.][^/]?|[^/][^/.]|[^/]{3,}))*$"
+      }
     }];
     // Whether to allow file paths not to exist within the given module.
     //

--- a/buf/registry/storage/v1beta1/storage.proto
+++ b/buf/registry/storage/v1beta1/storage.proto
@@ -56,11 +56,13 @@ message FileNode {
   //
   // The path must be relative, and connect contain any "." or ".." components
   // The separator "/" must be used.
-  //
-  // TODO: Can we encode the above requirements via validation?
   string path = 1 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 4096
+    (buf.validate.field).string = {
+      max_len: 1000,
+      not_contains: "\\",
+      pattern: "^([^/.][^/]?|[^/][^/.]|[^/]{3,})(/([^/.][^/]?|[^/][^/.]|[^/]{3,}))*$"
+    }
   ];
   // The digest of the file.
   //
@@ -77,11 +79,13 @@ message File {
   //
   // The path must be relative, and connect contain any "." or ".." components
   // The separator "/" must be used.
-  //
-  // TODO: Can we encode the above requirements via validation?
   string path = 1 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 4096
+    (buf.validate.field).string = {
+      max_len: 1000,
+      not_contains: "\\",
+      pattern: "^([^/.][^/]?|[^/][^/.]|[^/]{3,})(/([^/.][^/]?|[^/][^/.]|[^/]{3,}))*$"
+    }
   ];
   // Content is the content of the blob.
   //

--- a/buf/registry/storage/v1beta1/storage.proto
+++ b/buf/registry/storage/v1beta1/storage.proto
@@ -59,7 +59,7 @@ message FileNode {
   string path = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string = {
-      max_len: 1000,
+      max_len: 4096,
       not_contains: "\\",
       pattern: "^([^/.][^/]?|[^/][^/.]|[^/]{3,})(/([^/.][^/]?|[^/][^/.]|[^/]{3,}))*$"
     }
@@ -82,7 +82,7 @@ message File {
   string path = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string = {
-      max_len: 1000,
+      max_len: 4096,
       not_contains: "\\",
       pattern: "^([^/.][^/]?|[^/][^/.]|[^/]{3,})(/([^/.][^/]?|[^/][^/.]|[^/]{3,}))*$"
     }


### PR DESCRIPTION
* Rejects paths with backslashes
* Limits length to 4096 (will be enforced in v1alpha1 as well.)
* Enforces relative paths (no preceding slash.)
* Enforces no trailing slash
* Enforces normalized paths (no . or .. elements)

## Explanation
Regular expression breakdown:
```
Path := PathSegment(/PathSegment)*
PathSegment := [^/.][^/]?|[^/][^/.]|[^/]{3,}
```

* `Path` enforces normalized, relative paths by ensuring that there is one or more path segments with one and only one `/` between them and nowhere else.
* `PathSegment` enforces each path segment can't be `.` or `..` and must be non-empty. It does this by matching any 1 character segment that isn't `.`, any 2 character segment that isn't `..`, and any 3 character segment.

Overall path length is then enforced with `max_len` and Windows-style paths are rejected using `not_contains` to generally disallow backslashes in paths.