### PR TITLE
Remove UserServerRole

### DIFF
--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -74,7 +74,7 @@ message ListModulesRequest {
   // The specific Users or Organizations to list Modules for.
   //
   // If empty, all Modules for all owners are listed, but this functionality
-  // is only available for Users with the UserServerRole of USER_SERVER_ROLE_ADMIN.
+  // is limited to Users with the necessary permissions.
   repeated buf.registry.owner.v1beta1.OwnerRef owner_refs = 3;
 }
 

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -71,7 +71,7 @@ message ListOrganizationsRequest {
   // The ids of the specific Users to list Organizations for.
   //
   // If this is empty, all Organizations are listed, but this functionality
-  // is only available for Users with the UserServerRole of USER_SERVER_ROLE_ADMIN.
+  // is limited to Users with the necessary permissions.
   repeated UserRef user_refs = 3;
 }
 

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -54,20 +54,15 @@ message User {
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
-  // The role that the User has at the BSR instance level.
-  UserServerRole server_role = 7 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).enum.defined_only = true
-  ];
   // The configurable description of the User.
-  string description = 8 [(buf.validate.field).string.max_len = 350];
+  string description = 7 [(buf.validate.field).string.max_len = 350];
   // The configurable URL that represents the homepage for a User.
-  string url = 9 [
+  string url = 8 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 1023
   ];
   // The verification status of the User.
-  UserVerificationStatus verification_status = 10 [
+  UserVerificationStatus verification_status = 9 [
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
@@ -86,13 +81,6 @@ enum UserType {
   USER_TYPE_STANDARD = 1;
   USER_TYPE_MACHINE = 2;
   USER_TYPE_SYSTEM = 3;
-}
-
-// The role that the User has at the BSR instance level.
-enum UserServerRole {
-  USER_SERVER_ROLE_UNSPECIFIED = 0;
-  USER_SERVER_ROLE_STANDARD = 1;
-  USER_SERVER_ROLE_ADMIN = 2;
 }
 
 // The verification status of an User.

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -71,7 +71,7 @@ message ListUsersRequest {
   // The specific Organizations to list Users for.
   //
   // If this is empty, all Users for all Organizations are listed, but this functionality
-  // is only available for Users with the UserServerRole of USER_SERVER_ROLE_ADMIN.
+  // is limited to Users with the necessary permissions.
   repeated OrganizationRef organization_refs = 3;
 }
 
@@ -96,21 +96,17 @@ message CreateUsersRequest {
     //
     // If not set, the default USER_TYPE_STANDARD is used.
     UserType type = 2 [(buf.validate.field).enum.defined_only = true];
-    // The role that the User has at the BSR instance level.
-    //
-    // If not set, the default USER_SERVER_ROLE_STANDARD is used..
-    UserServerRole server_role = 3 [(buf.validate.field).enum.defined_only = true];
     // The configurable description of the User.
-    string description = 4 [(buf.validate.field).string.max_len = 350];
+    string description = 3 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for a User.
-    string url = 5 [
+    string url = 4 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 1023
     ];
     // The verification status of the User.
     //
     // If not set, the User will default to VERIFICATION_STATUS_UNVERIFIED.
-    UserVerificationStatus verification_status = 6 [(buf.validate.field).enum.defined_only = true];
+    UserVerificationStatus verification_status = 5 [(buf.validate.field).enum.defined_only = true];
   }
   // The Users to create.
   repeated Value values = 1 [
@@ -131,17 +127,15 @@ message UpdateUsersRequest {
     UserRef user_ref = 1 [(buf.validate.field).required = true];
     // The state of the User.
     optional UserState state = 2 [(buf.validate.field).enum.defined_only = true];
-    // The role that the User has at the BSR instance level.
-    optional UserServerRole server_role = 3 [(buf.validate.field).enum.defined_only = true];
     // The configurable description of the User.
-    optional string description = 4 [(buf.validate.field).string.max_len = 350];
+    optional string description = 3 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for a User.
-    optional string url = 5 [
+    optional string url = 4 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 1023
     ];
     // The verification status of the User.
-    optional UserVerificationStatus verification_status = 6 [(buf.validate.field).enum.defined_only = true];
+    optional UserVerificationStatus verification_status = 5 [(buf.validate.field).enum.defined_only = true];
   }
   // The Users to update.
   repeated Value values = 1 [


### PR DESCRIPTION
This PR removes `UserServerRole` in its entirety from the API surface. Putting this up for review/feedback, although need to think about this.

I'd go as far as removing the "special" handling of empty refs in the 3 endpoints and adding limits like other endpoints.

- ListModulesRequest
- ListOrganizationsRequest
- ListUsersRequest

Having the `UserServerRole` be a core primitive in the API is a potential footgun because in various places we're going to have conditional checks to expose, hide, or mask this field. Which may leak users with elevated privileges.

It feels there should be a dedicated `AdminService` either in the registry API or even better, an internal set of protos that aren't widely publicized. It'll be less error-prone to secure a whole service or RPC than an individual field.