### PR TITLE
Adjust validation for module name length

### DIFF
--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -87,8 +87,10 @@ message BranchRef {
     ];
     // The name of the Module that contains this Branch.
     string module = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string = {
+        min_len: 2,
+        max_len: 100
+      }
     ];
     // The name of the Branch.
     string branch = 3 [

--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -86,12 +86,10 @@ message BranchRef {
       (buf.validate.field).string.max_len = 255
     ];
     // The name of the Module that contains this Branch.
-    string module = 2 [
-      (buf.validate.field).string = {
-        min_len: 2,
-        max_len: 100
-      }
-    ];
+    string module = 2 [(buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }];
     // The name of the Branch.
     string branch = 3 [
       (buf.validate.field).required = true,

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -38,12 +38,10 @@ message Module {
   // The name of the Module.
   //
   // Unique within a given User or Organization.
-  string name = 4 [
-    (buf.validate.field).string = {
-      min_len: 2,
-      max_len: 100
-    }
-  ];
+  string name = 4 [(buf.validate.field).string = {
+    min_len: 2,
+    max_len: 100
+  }];
   // The id of the User or Organization that owns the Module.
   string owner_id = 5 [
     (buf.validate.field).required = true,
@@ -109,12 +107,10 @@ message ModuleRef {
       (buf.validate.field).string.max_len = 255
     ];
     // The name of the Module.
-    string module = 2 [
-      (buf.validate.field).string = {
-        min_len: 2,
-        max_len: 100
-      }
-    ];
+    string module = 2 [(buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }];
   }
 
   oneof value {

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -39,8 +39,10 @@ message Module {
   //
   // Unique within a given User or Organization.
   string name = 4 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }
   ];
   // The id of the User or Organization that owns the Module.
   string owner_id = 5 [
@@ -108,8 +110,10 @@ message ModuleRef {
     ];
     // The name of the Module.
     string module = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string = {
+        min_len: 2,
+        max_len: 100
+      }
     ];
   }
 

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -94,8 +94,10 @@ message CreateModulesRequest {
     buf.registry.owner.v1beta1.OwnerRef owner_ref = 1 [(buf.validate.field).required = true];
     // The name of the Module.
     string name = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string = {
+        min_len: 2,
+        max_len: 100
+      }
     ];
     // The module's visibility.
     ModuleVisibility visibility = 3 [

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -93,12 +93,10 @@ message CreateModulesRequest {
     // The User or Organization to create the Module under.
     buf.registry.owner.v1beta1.OwnerRef owner_ref = 1 [(buf.validate.field).required = true];
     // The name of the Module.
-    string name = 2 [
-      (buf.validate.field).string = {
-        min_len: 2,
-        max_len: 100
-      }
-    ];
+    string name = 2 [(buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }];
     // The module's visibility.
     ModuleVisibility visibility = 3 [
       (buf.validate.field).required = true,

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -67,12 +67,10 @@ message ResourceRef {
       (buf.validate.field).string.max_len = 255
     ];
     // The name of the Module the contains or is the resource.
-    string module = 2 [
-      (buf.validate.field).string = {
-        min_len: 2,
-        max_len: 100
-      }
-    ];
+    string module = 2 [(buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }];
     oneof child {
       // The name of the Branch.
       string branch_name = 3 [(buf.validate.field).string.max_len = 250];

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -68,8 +68,10 @@ message ResourceRef {
     ];
     // The name of the Module the contains or is the resource.
     string module = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string = {
+        min_len: 2,
+        max_len: 100
+      }
     ];
     oneof child {
       // The name of the Branch.

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -90,8 +90,10 @@ message TagRef {
     ];
     // The name of the Module that contains the Tag, either a User or Organization.
     string module = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string = {
+        min_len: 2,
+        max_len: 100
+      }
     ];
     // The Tag name.
     string tag = 3 [

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -89,12 +89,10 @@ message TagRef {
       (buf.validate.field).string.max_len = 255
     ];
     // The name of the Module that contains the Tag, either a User or Organization.
-    string module = 2 [
-      (buf.validate.field).string = {
-        min_len: 2,
-        max_len: 100
-      }
-    ];
+    string module = 2 [(buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }];
     // The Tag name.
     string tag = 3 [
       (buf.validate.field).required = true,

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -119,8 +119,10 @@ message VCSCommitRef {
     ];
     // The name of the Module that contains the VCSCommit.
     string module = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string = {
+        min_len: 2,
+        max_len: 100
+      }
     ];
     // The hash of the VCSCommit.
     string hash = 3 [

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -118,12 +118,10 @@ message VCSCommitRef {
       (buf.validate.field).string.max_len = 255
     ];
     // The name of the Module that contains the VCSCommit.
-    string module = 2 [
-      (buf.validate.field).string = {
-        min_len: 2,
-        max_len: 100
-      }
-    ];
+    string module = 2 [(buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }];
     // The hash of the VCSCommit.
     string hash = 3 [
       (buf.validate.field).required = true,


### PR DESCRIPTION
This matches the newly-unified v1alpha1 limits.

`required` does not seem to be necessary when `min_len` is present.