### PR TITLE
Document ResourceRef.ref to have equivalent behavior regardless of presence

### DIFF
--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -79,6 +79,9 @@ message ResourceRef {
       // The hash of the VCSCommit.
       string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
       // The untyped reference, applying the semantics as documented on the Name message.
+      //
+      // If this value is present but empty, this should be treated as not present, that is
+      // an empty value is the same as a null value.
       string ref = 6;
     }
   }


### PR DESCRIPTION
When building these objects, you sometimes have an empty value for `ref`, but know that you only have a `ref`, and you want to not have to write a lot of code to do empty string checking. IMO we should just document that empty is the same as null.