### PR TITLE
Make Digest a first-class citizen

### DIFF
--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -84,6 +84,7 @@ message ListBranchesRequest {
   //   - If a Tag is referenced, all Branches that contain the Tag are returned.
   //   - If a VCSCommit is referenced, all Branches that contain the VCSCommit are returned.
   //   - Is a Branch is referenced, this Branch is returned.
+  //   - If a Digest is referenced, all Branches that contain a Commit with this Digest are returned.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -78,6 +78,8 @@ message ResolveCommitsRequest {
   //   - If a Tag is referenced, this is interpreted to mean the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, this is interpreted to mean the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, this is interpreted to mean the latest Commit on the Branch.
+  //   - If a Digest is referenced, this is interpreted to mean the latest released Commit that has this Digest.
+  //     Digests referencing unreleased Commits cannot be referenced.
   repeated ResourceRef resource_refs = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
@@ -108,6 +110,8 @@ message ListCommitHistoryRequest {
   //   - If a Tag is referenced, history is started at the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, history is started at the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, history is started at the latest Commit on the Branch.
+  //   - If a Digest is referenced, history is started at the latest released Commit that has this Digest.
+  //     Digests referencing unreleased Commits cannot be referenced.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
   // Only return Commits that have one or more associated Tags.
   bool has_tag = 4;
@@ -160,10 +164,18 @@ message CreateCommitsRequest {
     string committer_email = 7;
   }
 
+  // A pointer to a dependency of a Module.
+  message DepNode {
+    // The reference to the Module to create a Commit for.
+    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
+    // The digest of the dependency.
+    buf.registry.storage.v1beta1.Digest digest = 2 [(buf.validate.field).required = true];
+  }
+
   // The pointers to the content of a single Module that a Commit will be created for.
   message ModuleNode {
     // The reference to the Module to create a Commit for.
-    ModuleRef module_ref = 1;
+    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The FileNodes for the Module.
     //
     // This consists of the .proto files, license files, and documentation files. This does
@@ -172,27 +184,17 @@ message CreateCommitsRequest {
     //
     // Blobs are shared across Modules within a given CreateCommit call; missing blobs
     // should be passed via the missing_blobs field. See GetMissingBlobDigests for more details.
-    repeated buf.registry.storage.v1beta1.FileNode file_nodes = 2;
+    repeated buf.registry.storage.v1beta1.FileNode file_nodes = 2 [(buf.validate.field).repeated.min_items = 1];
+    // The dependencies of the Module.
+    repeated DepNode dep_nodes = 3;
   }
 
-  // A pointer to a dependency of a Module.
-  message DepNode {
-    // The ID of the the Commit of the dependency.
-    string commit_id = 1 [(buf.validate.field).required = true];
-    // The digest of the dependency.
-    buf.registry.storage.v1beta1.Digest digest = 2 [(buf.validate.field).required = true];
-  }
 
   // The pointers to the content for the Modules that should have Commits created for them.
   //
   // Each ModuleNode must have a unique ModuleRef.
   // A commit will be created for each ModuleNode.
   repeated ModuleNode module_nodes = 1 [(buf.validate.field).repeated.min_items = 1];
-  // The dependencies of the Modules that are not contained within module_nodes.
-  //
-  // No dep should reference a Commit that is within a Module referenced by module_ref on
-  // any of the ModuleNodes in module_nodes.
-  repeated DepNode dep_nodes = 2;
   // Blobs for the FileNodes referenced by module_nodes that are not present on the server.
   //
   // Only Blobs that were returned as missing from GetMissingBlobDigests need to be sent.
@@ -200,14 +202,14 @@ message CreateCommitsRequest {
   //
   // If a FileNode within module_nodes has a Blob that is not on the server, and is not
   // within missing_blobs, an error will be returned.
-  repeated buf.registry.storage.v1beta1.Blob missing_blobs = 3;
+  repeated buf.registry.storage.v1beta1.Blob missing_blobs = 2;
   // The names of Branches that should be associated with this Commit.
   //
   // If a Branch currently exists on the associated Module with a name, this existing
   // Branch will be used. Otherwise, a new Branch will be created for the corresponding name.
   //
   // If empty, the default branch is assumed as the only branch.
-  repeated string branch_names = 4 [(buf.validate.field).repeated.items = {
+  repeated string branch_names = 3 [(buf.validate.field).repeated.items = {
     string: {max_len: 250}
   }];
   // The names of Tags that should be associated with this Commit.
@@ -215,14 +217,14 @@ message CreateCommitsRequest {
   // If a Tag currently exists on the assocated Module with a name, the RPC will error, however
   // this will change in the future when we allow Tags to move. If the Tag does not
   // currently exist, a new Tag will be created for each name.
-  repeated string tag_names = 5 [(buf.validate.field).repeated.items = {
+  repeated string tag_names = 4 [(buf.validate.field).repeated.items = {
     string: {max_len: 250}
   }];
   // Associated VCS commit information.
   //
   // If there are already VCSCommits on the associated Module with a given hash, this
   // will result in an error. Otherwise, a new VCSCommit is created.
-  repeated AssociatedVCSCommit associated_vcs_commits = 6;
+  repeated AssociatedVCSCommit associated_vcs_commits = 5;
 }
 
 message CreateCommitsResponse {
@@ -246,6 +248,8 @@ message GetCommitNodesRequest {
     //   - If a Tag is referenced, files are returned from the Commit associated with the Tag.
     //   - If a VCSCommit is referenced, files are returned from the Commit associated with the VCSCommit.
     //   - Is a Branch is referenced, files are returned from the latest Commit on the Branch.
+    //   - If a Digest is referenced, files are returned from the latest released Commit that has this Digest.
+    //     Digests referencing unreleased Commits cannot be referenced.
     ResourceRef resource_ref = 1 [(buf.validate.field).required = true];
     // Specific file paths to retrieve.
     //

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -189,7 +189,6 @@ message CreateCommitsRequest {
     repeated DepNode dep_nodes = 3;
   }
 
-
   // The pointers to the content for the Modules that should have Commits created for them.
   //
   // Each ModuleNode must have a unique ModuleRef.

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package buf.registry.module.v1beta1;
 
 import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -44,13 +45,16 @@ message ResourceRef {
   //   - If the child oneof is not specified, the name is interpreted to reference a Module.
   //   - If branch_name is specified, the name is interpreted to reference a Branch.
   //   - If tag_name is specified, the name is interpreted to reference a Tag.
-  //   - If vcs_commit_hash is specified, the name is interpeted to reference a VCSCommit.
+  //   - If vcs_commit_hash is specified, the name is interpreted to reference a VCSCommit.
+  //   - If digest is specified, the name is interpreted to reference a Commit with this Digest.
   //   - If ref is specified, it is interpreted to be either an id or name.
   //     - If an id, this is equivalent to setting the id field on ResourceRef. However,
   //       backends can choose to validate that the owner and module fields match the resource
   //       referenced, as additional validation.
   //     - If a name, this is interpreted to be either a Branch name, Tag name,
-  //       or VCSCommit hash.
+  //       VCSCommit hash, or Digest string. A digest string is of the form "typeString:hexValue",
+  //       where typeString is the lowercase of the Type value with TYPE_ stripped, and hexValue
+  //       is the hex-encoded value of the digest.
   //     - If there is a conflict between names across resources (for example, there is a
   //       Branch and Tag with the same name), the following order of precedence is applied:
   //       - Commit
@@ -78,11 +82,13 @@ message ResourceRef {
       string tag_name = 4 [(buf.validate.field).string.max_len = 250];
       // The hash of the VCSCommit.
       string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
+      // The digest of the Commit.
+      buf.registry.storage.v1beta1.Digest digest = 6;
       // The untyped reference, applying the semantics as documented on the Name message.
       //
       // If this value is present but empty, this should be treated as not present, that is
       // an empty value is the same as a null value.
-      string ref = 6;
+      string ref = 7;
     }
   }
 

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -79,6 +79,9 @@ message ResourceRef {
       // The hash of the VCSCommit.
       string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
       // The untyped reference, applying the semantics as documented on the Name message.
+      //
+      // If this value is present but empty, this should be treated as not present, that is
+      // an empty value is the same as a null value.
       string ref = 6;
     }
   }

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -75,6 +75,7 @@ message ListTagsRequest {
   //   - If a Tag is referenced, this Tag is returned.
   //   - If a VCSCommit is referenced, all Tags for commits that the VCSCommit is associated with are returned.
   //   - Is a Branch is referenced, all Tags for Commits on the Branch are returned.
+  //   - If a Digest is referenced, all Tags that contain a Commit with this Digest are returned.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 

--- a/buf/registry/module/v1beta1/vcs_commit_service.proto
+++ b/buf/registry/module/v1beta1/vcs_commit_service.proto
@@ -67,6 +67,7 @@ message ListVCSCommitsRequest {
   //   - If a Tag is referenced, all VCSCommits for the Commit associated with the Tag are returned.
   //   - If a VCSCommit is referenced, this VCSCommit is returned.
   //   - Is a Branch is referenced, all VCSCommits associated with Commits on the Branch are returned.
+  //   - If a Digest is referenced, all VCSCommits associated with Commits with this Digest are returned.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 


### PR DESCRIPTION
@saquibmian context:

Buckle up, here we go!

### A `Digest` uniquely identifies the content it closes over

First, a `Digest` uniquely identifies the content it closes over. Here's how we get to this conclusion:

1. Every `Commit` has a set of `Digests`.
    - For `Digest`s of type shake256 -- which is the `Digest` we write in lock files today -- this includes:
        - all protos (file and path)
        - `buf.yaml` (or other config file)
        - `buf.lock`
        - the single documentation file path
        - license file and path
    - For `Digests` of type b3, this includes:
        - all protos 
        - dependencies (module identity and commit name)
        - the single documentation file and path
        - license file and path
        - breaking and lint configs
    - We will refer to the content that the digest closes over as `Content`.
2. Two `Commit`s with identical `Content` (i.e., config, files, and dependencies) will produce the same `Digest`. Today we use this property to short-circuit creating a new `Commit` if nothing in your module has changed.
2. Therefore, a `Digest` uniquely identifies a `Content`, i.e., the content it closes over.

### A `Digest` is a resolvable reference

1. Given a particular `Digest`, we can resolve a set of `Commit`s whose set of `Digest`s contain that value. The commits will have varying _metadata_ (repository, create time, branch, author, etc.), but the `Content` of the commits is identical -- and in fact even hashes to the same location in the CAS store.
    - In other words, a `Commit` is really just a pairing of some metadata and `Content`, and `Content` is reused across commits (sometimes, not all the time) and may even exist in various registries (this has implications for federation).
2. Given that a `Digest` uniquely identifies the content it closes over, and that a `Commit` is a pairing of some metadata and the content it closes over, we can resolve the set of `Commit`s associated with a `Digest`.
3. If there is only one `Commit` with that `Digest`, we have resolved a `Digest` to a `Commit`.
4. If there is more than one `Commit` with that `Digest`, we can further resolve to a _single_ `Commit` by considering only the _latest Released_ `Commit`.
5. If we do this, this makes all `Digests` resolvable references. Importantly, this also makes the `Digest` a resolvable _dependency_ reference.

### Tieing this all together

The fundamental problem with Workspace Push is that `Modules` have to be pushed in topological order, and if a new `Commit` is created, the `buf.lock` file for the consuming `Module` has to be updated to pin to that `Commit` before it can be pushed.

We can Push a Workspace if we can do all of this in a deterministic fashion, client-side. Today, because a `ModulePin` has the `Commit`'s `name`, we can't. We have needed the name to resolve the `ModulePin` to a `Commit`, but we have just proven that we can resolve the `ModulePin` to a `Commit` via a `Digest` instead.

Therefore, if we drop `Commit.name` from a `ModulePin`, we can determinstically generate a `ModulePin` to a `Commit` _that hasn't even been pushed yet_. All that remains is to Push in topological order, which is the easy part.

To implement this, we do the following:

1. Add `Digest` to `ResourceRef.Name`. If a `Digest` is specified, the name is interpreted to reference a `Commit` with that `Digest`.
2. Update all `List*` requests to include valid semantics for when a `Digest` is passed as a reference:
    - for `Branch`s, include all `Branch`s that contain a `Commit` with that `Digest`.
    - for `Tag`s, include all `Tag`s that are associated with `Commit`s with that `Digest`.
    - for `VCSCommit`, include all `VSCCommit`s that are associated with `Commit`s with that `Digest`.
    - for `Commit`, include the latest released `Commit` that has that `Digest`.
3. Update `CreateCommits` to do the following:
    1. Change `DepNode`, replacing `Commit.ID` with `Digest`. All dependencies references `Digest`s.
    2. Move `DepNode`s to be part of a `ModuleNode`. A `ModuleNode` would include a `DepNode` for all declared dependencies (pruned or not, doesn't matter) _and a `DepNode` for any workspace modules it imports, even though they haven't been pushed_.

With this change, as long as `ModuleNode`s are sent in topological order, and the BSR respects that ordering, multiple commits can be created in a single transaction and resolve dependencies (by `Digest`) that were also created in that transaction, thereby enabling Workspace Push.

This only works with `buf.yaml` v2, because Workspace dependencies are not in the `buf.lock`, but this can _also_ work with `buf.yaml` v1 if we choose to allow `buf mod update` on a Workspace, and it would update `buf.lock` files to what they _should_ be post Push. As long as we push in topological order, one at a time, this will all work.

Let me know if any of this is crazy, in my mind all of this works, but it needs to be thoroughly vetted to make sure it's sane.



