### PR TITLE
Adjust validation for VCS Commit Hash

### DIFF
--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -133,7 +133,7 @@ message CreateCommitsRequest {
     // Unique within a given Module.
     string hash = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.pattern = "^[0-9a-fA-F]{40}$"
     ];
     // The type of VCS.
     VCSType type = 2 [

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -77,7 +77,7 @@ message ResourceRef {
       // The name of the Tag.
       string tag_name = 4 [(buf.validate.field).string.max_len = 250];
       // The hash of the VCSCommit.
-      string vcs_commit_hash = 5 [(buf.validate.field).string.max_len = 255];
+      string vcs_commit_hash = 5 [(buf.validate.field).string.pattern = "^[0-9a-fA-F]{40}$"];
       // The untyped reference, applying the semantics as documented on the Name message.
       //
       // If this value is present but empty, this should be treated as not present, that is

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -47,7 +47,7 @@ message VCSCommit {
   // Unique within a given Module.
   string hash = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.pattern = "^[0-9a-fA-F]{40}$"
   ];
   // The id of the User or Organization that owns the Module that the VCSCommit is associated with.
   string owner_id = 5 [
@@ -125,7 +125,7 @@ message VCSCommitRef {
     // The hash of the VCSCommit.
     string hash = 3 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.pattern = "^[0-9a-fA-F]{40}$"
     ];
   }
 


### PR DESCRIPTION
We currently only support Git SHA1 hashes and nothing else. In the future, adding a union to this regex could allow more hash shapes for different VCSes or different Git repository digests.

<!-- References BSR-2930 -->