### PR TITLE
Adjust owner name length validation

### DIFF
--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -83,7 +83,7 @@ message BranchRef {
     // The name of the User or Organization that owns the Module that contains this Branch.
     string owner = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 32
     ];
     // The name of the Module that contains this Branch.
     string module = 2 [(buf.validate.field).string = {

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -104,7 +104,7 @@ message ModuleRef {
     // The name of the owner of the Module, either a User or Organization.
     string owner = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 32
     ];
     // The name of the Module.
     string module = 2 [(buf.validate.field).string = {

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -64,7 +64,7 @@ message ResourceRef {
     // The name of the User or Organization that owns the resource.
     string owner = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 32
     ];
     // The name of the Module the contains or is the resource.
     string module = 2 [(buf.validate.field).string = {

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -86,7 +86,7 @@ message TagRef {
     // The name of the owner of the Module that contains the Tag, either a User or Organization.
     string owner = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 32
     ];
     // The name of the Module that contains the Tag, either a User or Organization.
     string module = 2 [(buf.validate.field).string = {

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -115,7 +115,7 @@ message VCSCommitRef {
     // The name of the owner of the Module that contains the VCSCommit, either a user or organization.
     string owner = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 32
     ];
     // The name of the Module that contains the VCSCommit.
     string module = 2 [(buf.validate.field).string = {

--- a/buf/registry/owner/v1beta1/organization.proto
+++ b/buf/registry/owner/v1beta1/organization.proto
@@ -42,7 +42,7 @@ message Organization {
   // A name uniquely identifies an Organization, however name is mutable.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 32
   ];
   // The configurable description of the Organization.
   string description = 5 [(buf.validate.field).string.max_len = 350];
@@ -82,7 +82,7 @@ message OrganizationRef {
     // The name of the Organization.
     string name = 2 [(buf.validate.field).string = {
       min_len: 1;
-      max_len: 255;
+      max_len: 32;
     }];
   }
 }

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -90,7 +90,7 @@ message CreateOrganizationsRequest {
     // The name of the Organization.
     string name = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 32
     ];
     // The configurable description of the Organization.
     string description = 2 [(buf.validate.field).string.max_len = 350];

--- a/buf/registry/owner/v1beta1/owner.proto
+++ b/buf/registry/owner/v1beta1/owner.proto
@@ -49,7 +49,7 @@ message OwnerRef {
     // The name of the User or Organization.
     string name = 2 [(buf.validate.field).string = {
       min_len: 1;
-      max_len: 255;
+      max_len: 32;
     }];
   }
 }

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -42,7 +42,7 @@ message User {
   // A name uniquely identifies a User, however name is mutable.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 32
   ];
   // The type of the User.
   UserType type = 5 [
@@ -108,7 +108,7 @@ message UserRef {
     // The name of the User.
     string name = 2 [(buf.validate.field).string = {
       min_len: 1;
-      max_len: 255;
+      max_len: 32;
     }];
   }
 }

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -90,7 +90,7 @@ message CreateUsersRequest {
     // The name of the User.
     string name = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 32
     ];
     // The type of the User.
     //


### PR DESCRIPTION
Adjusts the maximum owner name length to 32, as it is in v1alpha1. As per resolution in other discussions, we won't validate the minimum length at the protovalidate level.

<!-- References BSR-2930. -->