### PR TITLE
Fix missing blobs request/response

### DIFF
--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -310,7 +310,8 @@ message GetBlobsResponse {
 }
 
 message GetMissingBlobDigestsRequest {
-  message ModuleBlobDigests {
+  // A set of blob Digests associated with a Module.
+  message Value {
     // The reference to the Module that the digests belong to.
     ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The digests to see if we have Blobs for.
@@ -319,19 +320,20 @@ message GetMissingBlobDigestsRequest {
       (buf.validate.field).repeated.max_items = 250
     ];
   }
-  repeated ModuleBlobDigests module_blob_digests = 1 [
+  repeated Value values = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
   ];
 }
 
 message GetMissingBlobDigestsResponse {
-  message MissingBlobDigest {
+  // A set of missing blob Digests associated with a Module.
+  message Value {
     // The Module that the missing digests are for.
     Module module = 1 [(buf.validate.field).required = true];
     // The digests that are missing.
-    repeated buf.registry.storage.v1beta1.Digest missing_blob_digests = 2;
+    repeated buf.registry.storage.v1beta1.Digest missing_blob_digests = 2 [(buf.validate.field).repeated.min_items = 1];
   }
   // The digests that are missing.
-  repeated MissingBlobDigest missing_blob_digests = 1;
+  repeated Value values = 1;
 }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -319,7 +319,10 @@ message GetMissingBlobDigestsRequest {
       (buf.validate.field).repeated.max_items = 250
     ];
   }
-  repeated ModuleBlobDigests module_blob_digests = 1;
+  repeated ModuleBlobDigests module_blob_digests = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetMissingBlobDigestsResponse {

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -297,16 +297,37 @@ message GetCommitNodesResponse {
 }
 
 message GetBlobsRequest {
-  // The digests to retrieve Blobs for.
-  repeated buf.registry.storage.v1beta1.Digest digests = 1 [
+  // A set of blog Digests associated with a Module.
+  message Value {
+    // The reference to the Module that the Blobs belong to.
+    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
+    // The Digests to retrieve Blobs for.
+    repeated buf.registry.storage.v1beta1.Digest blob_digests = 2 [
+      (buf.validate.field).repeated.min_items = 1,
+      (buf.validate.field).repeated.max_items = 250
+    ];
+  }
+  repeated Value values = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
   ];
 }
 
 message GetBlobsResponse {
-  // The retrieved Blobs.
-  repeated buf.registry.storage.v1beta1.Blob blobs = 1 [(buf.validate.field).repeated.min_items = 1];
+  // A set of missing blob Digests associated with a Module.
+  message Value {
+    // The Module that associated with the Blobs.
+    Module module = 1 [(buf.validate.field).required = true];
+    // The retrieved Blobs.
+    repeated buf.registry.storage.v1beta1.Blob blobs = 2 [
+      (buf.validate.field).repeated.min_items = 1,
+      (buf.validate.field).repeated.max_items = 250
+    ];
+  }
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
 }
 
 message GetMissingBlobDigestsRequest {
@@ -314,7 +335,7 @@ message GetMissingBlobDigestsRequest {
   message Value {
     // The reference to the Module that the digests belong to.
     ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-    // The digests to see if we have Blobs for.
+    // The Digests to see if we have Blobs for.
     repeated buf.registry.storage.v1beta1.Digest blob_digests = 2 [
       (buf.validate.field).repeated.min_items = 1,
       (buf.validate.field).repeated.max_items = 250

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -327,8 +327,8 @@ message GetMissingBlobDigestsRequest {
 
 message GetMissingBlobDigestsResponse {
   message MissingBlobDigest {
-    // The reference to the Module that the missing digests are for.
-    ModuleRef module_ref = 1;
+    // The Module that the missing digests are for.
+    Module module = 1 [(buf.validate.field).required = true];
     // The digests that are missing.
     repeated buf.registry.storage.v1beta1.Digest missing_blob_digests = 2;
   }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -312,7 +312,7 @@ message GetBlobsResponse {
 message GetMissingBlobDigestsRequest {
   message ModuleBlobDigests {
     // The reference to the Module that the digests belong to.
-    ModuleRef module = 1;
+    ModuleRef module_ref = 1;
     // The digests to see if we have Blobs for.
     repeated buf.registry.storage.v1beta1.Digest blob_digests = 2 [
       (buf.validate.field).repeated.min_items = 1,
@@ -328,7 +328,7 @@ message GetMissingBlobDigestsRequest {
 message GetMissingBlobDigestsResponse {
   message MissingBlobDigest {
     // The reference to the Module that the missing digests are for.
-    ModuleRef module = 1;
+    ModuleRef module_ref = 1;
     // The digests that are missing.
     repeated buf.registry.storage.v1beta1.Digest missing_blob_digests = 2;
   }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -310,14 +310,25 @@ message GetBlobsResponse {
 }
 
 message GetMissingBlobDigestsRequest {
-  // The digests to see if we have Blobs for.
-  repeated buf.registry.storage.v1beta1.Digest digests = 1 [
-    (buf.validate.field).repeated.min_items = 1,
-    (buf.validate.field).repeated.max_items = 250
-  ];
+  message ModuleBlobDigests {
+    // The reference to the Module that the digests belong to.
+    ModuleRef module = 1;
+    // The digests to see if we have Blobs for.
+    repeated buf.registry.storage.v1beta1.Digest blob_digests = 2 [
+      (buf.validate.field).repeated.min_items = 1,
+      (buf.validate.field).repeated.max_items = 250
+    ];
+  }
+  repeated ModuleBlobDigests module_blob_digests = 1;
 }
 
 message GetMissingBlobDigestsResponse {
+  message MissingBlobDigest {
+    // The reference to the Module that the missing digests are for.
+    ModuleRef module = 1;
+    // The digests that are missing.
+    repeated buf.registry.storage.v1beta1.Digest missing_blob_digests = 2;
+  }
   // The digests that are missing.
-  repeated buf.registry.storage.v1beta1.Digest missing_blob_digests = 1;
+  repeated MissingBlobDigest missing_blob_digests = 1;
 }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -312,7 +312,7 @@ message GetBlobsResponse {
 message GetMissingBlobDigestsRequest {
   message ModuleBlobDigests {
     // The reference to the Module that the digests belong to.
-    ModuleRef module_ref = 1;
+    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The digests to see if we have Blobs for.
     repeated buf.registry.storage.v1beta1.Digest blob_digests = 2 [
       (buf.validate.field).repeated.min_items = 1,


### PR DESCRIPTION
Blobs are not globally addressable across the BSR, largely for SOC2 compliance so that we can safely and cheaply delete all assets for a repository. Blobs are scoped to a repository.

Therefore, when we query for missing blobs, we have to query for missing blobs in the context of a `ModuleRef`. I chose to take the route of querying for multiple sets of module blobs in a single request rather than one request per set of module blobs.