### PR TITLE
Allow tags to move

### DIFF
--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -216,8 +216,8 @@ message CreateCommitsRequest {
   }];
   // The names of Tags that should be associated with this Commit.
   //
-  // If a Tag currently exists on the associated Module with a name, the Tag will move to this
-  // commit. If the Tag does not currently exist, a new Tag will be created for the name.
+  // If a Tag currently exists on the associated Module with a name, the Tag will be updated
+  // to reference this commit. Otherwise, a new Tag will be created for the name.
   repeated string tag_names = 4 [(buf.validate.field).repeated.items = {
     string: {max_len: 250}
   }];

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -78,11 +78,11 @@ message ResolveCommitsRequest {
   //   - If a Module is referenced, this is interpreted to mean the latest released Commit on the Module.
   //   - If a Commit is referenced, this just references that specific commit.
   //   - If a Tag is referenced, this is interpreted to mean the released Commit associated with the Tag.
-  //     Tags referencing unreleased commits cannot be referenced.
+  //     Tags referencing unreleased commits cannot be resolved.
   //   - If a VCSCommit is referenced, this is interpreted to mean the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, this is interpreted to mean the latest Commit on the Branch.
   //   - If a Digest is referenced, this is interpreted to mean the latest released Commit that has this Digest.
-  //     Digests referencing unreleased Commits cannot be referenced.
+  //     Digests referencing unreleased Commits cannot be resolved.
   repeated ResourceRef resource_refs = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -77,7 +77,8 @@ message ResolveCommitsRequest {
   // Once the resource is resolved, this reference is interpeted to refer to the following Commit:
   //   - If a Module is referenced, this is interpreted to mean the latest released Commit on the Module.
   //   - If a Commit is referenced, this just references that specific commit.
-  //   - If a Tag is referenced, this is interpreted to mean the Commit associated with the Tag.
+  //   - If a Tag is referenced, this is interpreted to mean the released Commit associated with the Tag.
+  //     Tags referencing unreleased commits cannot be referenced.
   //   - If a VCSCommit is referenced, this is interpreted to mean the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, this is interpreted to mean the latest Commit on the Branch.
   //   - If a Digest is referenced, this is interpreted to mean the latest released Commit that has this Digest.
@@ -215,9 +216,8 @@ message CreateCommitsRequest {
   }];
   // The names of Tags that should be associated with this Commit.
   //
-  // If a Tag currently exists on the assocated Module with a name, the RPC will error, however
-  // this will change in the future when we allow Tags to move. If the Tag does not
-  // currently exist, a new Tag will be created for each name.
+  // If a Tag currently exists on the associated Module with a name, the Tag will move to this
+  // commit. If the Tag does not currently exist, a new Tag will be created for the name.
   repeated string tag_names = 4 [(buf.validate.field).repeated.items = {
     string: {max_len: 250}
   }];

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -77,8 +77,7 @@ message ResolveCommitsRequest {
   // Once the resource is resolved, this reference is interpeted to refer to the following Commit:
   //   - If a Module is referenced, this is interpreted to mean the latest released Commit on the Module.
   //   - If a Commit is referenced, this just references that specific commit.
-  //   - If a Tag is referenced, this is interpreted to mean the released Commit associated with the Tag.
-  //     Tags referencing unreleased commits cannot be resolved.
+  //   - If a Tag is referenced, this is interpreted to mean the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, this is interpreted to mean the Commit associated with the VCSCommit.
   //   - Is a Branch is referenced, this is interpreted to mean the latest Commit on the Branch.
   //   - If a Digest is referenced, this is interpreted to mean the latest released Commit that has this Digest.

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -25,7 +25,8 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 
 // A tag on a specific Module.
 //
-// Many Tags can be associated with a single Commit.
+// Many Tags can be associated with a single Commit. A tag can reference any commit, including
+// unreleased commits.
 message Tag {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
@@ -37,9 +38,6 @@ message Tag {
   // The time the Tag was created on the BSR.
   google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
   // The last time the Tag was updated on the BSR.
-  //
-  // Currently, Tags are immutable, but this may change in the near future.
-  // TODO: is this true?
   google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
   // The name of the Tag.
   //

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -39,10 +39,10 @@ service TagService {
   rpc CreateTags(CreateTagsRequest) returns (CreateTagsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
-  // Create new Tags on a Module, and Update existing Tags on a Module.
+  // Update existing Tags on a Module.
   //
-  // This operation is atomic. Either all Tags are created/updated or an error is returned.
-  rpc CreateOrUpdateTags(CreateOrUpdateTagsRequest) returns (CreateOrUpdateTagsResponse) {
+  // This operation is atomic. Either all Tags are updated or an error is returned.
+  rpc UpdateTags(UpdateTagsRequest) returns (UpdateTagsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
   // Delete existing Tags.
@@ -101,26 +101,18 @@ message ListTagsResponse {
 message CreateTagsRequest {
   // An individual request to create a Tag.
   message Value {
+    // The Module to create the Tag under.
+    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The Tag name.
-    //
-    // If there is already a Tag with a name, the request errors. Otherwise, a new Tag will be
-    // created associated with the commit identified.
-    repeated string name = 1 [
+    string name = 2 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.max_len = 250
     ];
-    // The reference to resolve the Commit to which these Tags will be set.
-    //
-    // See the documentation on Ref for resource resolution details.
-    //
-    // The Tags are set depending on the kind of resource that is resolved:
-    //   - If a Module is referenced, Tags are set to the latest released Commit in the module.
-    //   - If a Commit is referenced, Tags are set for that Commit.
-    //   - If a Tag is referenced, Tags are set for the Commit that this Tag references.
-    //   - If a VCSCommit is referenced, Tags are set for the Commit that this VCSCommit references.
-    //   - Is a Branch is referenced, Tags are set for the latest Commit on the Branch.
-    //   - If a Digest is referenced, Tags are set for the most recent Commit with this Digest.
-    ResourceRef resource_ref = 2 [(buf.validate.field).required = true];
+    // The id of the Commit associated with the Tag.
+    string commit_id = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.uuid = true
+    ];
   }
   // The Tags to create.
   repeated Value values = 1 [
@@ -134,40 +126,23 @@ message CreateTagsResponse {
   repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message CreateOrUpdateTagsRequest {
-  // An individual request to create or update a Tag.
+message UpdateTagsRequest {
+  // An individual request to update a Tag.
   message Value {
-    // The Tag names.
-    //
-    // If there is already a Tag with a name, it will be updated to be associated with
-    // the commit identified. Otherwise, a new Tag will be created associated with the
-    // commit identified.
-    repeated string name = 1 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 250
-    ];
-    // The reference to resolve the Commit to which these Tags will be set.
-    //
-    // See the documentation on Ref for resource resolution details.
-    //
-    // The Tags are set depending on the kind of resource that is resolved:
-    //   - If a Module is referenced, Tags are set to the latest released Commit in the module.
-    //   - If a Commit is referenced, Tags are set for that Commit.
-    //   - If a Tag is referenced, Tags are set for the Commit that this Tag references.
-    //   - If a VCSCommit is referenced, Tags are set for the Commit that this VCSCommit references.
-    //   - Is a Branch is referenced, Tags are set for the latest Commit on the Branch.
-    //   - If a Digest is referenced, Tags are set for the most recent Commit with this Digest.
-    ResourceRef resource_ref = 2 [(buf.validate.field).required = true];
+    // The Tag to update.
+    TagRef tag_ref = 1 [(buf.validate.field).required = true];
+    // The id of the Commit associated with the Tag.
+    optional string commit_id = 2 [(buf.validate.field).string.uuid = true];
   }
-  // The Tags to create or update.
+  // The Tags to update.
   repeated Value values = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
   ];
 }
 
-message CreateOrUpdateTagsResponse {
-  // The created or updated Tags in the same order as given on the request.
+message UpdateTagsResponse {
+  // The updated Tags in the same order as given on the request.
   repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -39,10 +39,10 @@ service TagService {
   rpc CreateTags(CreateTagsRequest) returns (CreateTagsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
-  // Move existing Tags on a Module.
+  // Create new Tags on a Module, and Update existing Tags on a Module.
   //
-  // This operation is atomic. Either all Tags are moved or an error is returned.
-  rpc MoveTags(MoveTagsRequest) returns (MoveTagsResponse) {
+  // This operation is atomic. Either all Tags are created/updated or an error is returned.
+  rpc CreateOrUpdateTags(CreateOrUpdateTagsRequest) returns (CreateOrUpdateTagsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
   // Delete existing Tags.
@@ -101,18 +101,26 @@ message ListTagsResponse {
 message CreateTagsRequest {
   // An individual request to create a Tag.
   message Value {
-    // The Module to create the Tag under.
-    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The Tag name.
-    string name = 2 [
+    //
+    // If there is already a Tag with a name, the request errors. Otherwise, a new Tag will be
+    // created associated with the commit identified.
+    repeated string name = 1 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.max_len = 250
     ];
-    // The id of the Commit associated with the Tag.
-    string commit_id = 3 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.uuid = true
-    ];
+    // The reference to resolve the Commit to which these Tags will be set.
+    //
+    // See the documentation on Ref for resource resolution details.
+    //
+    // The Tags are set depending on the kind of resource that is resolved:
+    //   - If a Module is referenced, Tags are set to the latest released Commit in the module.
+    //   - If a Commit is referenced, Tags are set for that Commit.
+    //   - If a Tag is referenced, Tags are set for the Commit that this Tag references.
+    //   - If a VCSCommit is referenced, Tags are set for the Commit that this VCSCommit references.
+    //   - Is a Branch is referenced, Tags are set for the latest Commit on the Branch.
+    //   - If a Digest is referenced, Tags are set for the most recent Commit with this Digest.
+    ResourceRef resource_ref = 2 [(buf.validate.field).required = true];
   }
   // The Tags to create.
   repeated Value values = 1 [
@@ -126,31 +134,40 @@ message CreateTagsResponse {
   repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message MoveTagsRequest {
-  // An individual request to move a Tag.
+message CreateOrUpdateTagsRequest {
+  // An individual request to create or update a Tag.
   message Value {
-    // The Module associated with the Tag.
-    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-    // The Tag name.
-    string name = 2 [
+    // The Tag names.
+    //
+    // If there is already a Tag with a name, it will be updated to be associated with
+    // the commit identified. Otherwise, a new Tag will be created associated with the
+    // commit identified.
+    repeated string name = 1 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.max_len = 250
     ];
-    // The id of the Commit to associate with the Tag.
-    string commit_id = 3 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.uuid = true
-    ];
+    // The reference to resolve the Commit to which these Tags will be set.
+    //
+    // See the documentation on Ref for resource resolution details.
+    //
+    // The Tags are set depending on the kind of resource that is resolved:
+    //   - If a Module is referenced, Tags are set to the latest released Commit in the module.
+    //   - If a Commit is referenced, Tags are set for that Commit.
+    //   - If a Tag is referenced, Tags are set for the Commit that this Tag references.
+    //   - If a VCSCommit is referenced, Tags are set for the Commit that this VCSCommit references.
+    //   - Is a Branch is referenced, Tags are set for the latest Commit on the Branch.
+    //   - If a Digest is referenced, Tags are set for the most recent Commit with this Digest.
+    ResourceRef resource_ref = 2 [(buf.validate.field).required = true];
   }
-  // The Tags to move.
+  // The Tags to create or update.
   repeated Value values = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
   ];
 }
 
-message MoveTagsResponse {
-  // The moved Tags in the same order as given on the request.
+message CreateOrUpdateTagsResponse {
+  // The created or updated Tags in the same order as given on the request.
   repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -39,6 +39,12 @@ service TagService {
   rpc CreateTags(CreateTagsRequest) returns (CreateTagsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
+  // Move existing Tags on a Module.
+  //
+  // This operation is atomic. Either all Tags are moved or an error is returned.
+  rpc MoveTags(MoveTagsRequest) returns (MoveTagsResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
   // Delete existing Tags.
   //
   // This operation is atomic. Either all Tags are deleted or an error is returned.
@@ -117,6 +123,34 @@ message CreateTagsRequest {
 
 message CreateTagsResponse {
   // The created Tags in the same order as given on the request.
+  repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message MoveTagsRequest {
+  // An individual request to move a Tag.
+  message Value {
+    // The Module associated with the Tag.
+    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
+    // The Tag name.
+    string name = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 250
+    ];
+    // The id of the Commit to associate with the Tag.
+    string commit_id = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.uuid = true
+    ];
+  }
+  // The Tags to move.
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message MoveTagsResponse {
+  // The moved Tags in the same order as given on the request.
   repeated Tag tags = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 


### PR DESCRIPTION
Sync requires this behaviour. I also added the `UpdateTags` RPC.

We maintain the inability to reference a Tag on an unreleased Commit, which is consistent with v1alpha1.