### PR TITLE
Adjust page token validation

### DIFF
--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -73,7 +73,7 @@ message ListBranchesRequest {
   // The page to start from.
   //
   // If empty, the first page is returned,
-  string page_token = 2;
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The reference to list Branches for.
   //
   // See the documentation on Ref for resource resolution details.
@@ -92,7 +92,7 @@ message ListBranchesResponse {
   // The next page token.
   //
   /// If empty, there are no more pages.
-  string next_page_token = 1;
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The listed Branches.
   repeated Branch branches = 2;
 }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -101,7 +101,7 @@ message ListCommitHistoryRequest {
   // The page to start from.
   //
   // If empty, the first page is returned.
-  string page_token = 2;
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The reference to get the history for.
   //
   // See the documentation on ResourceRef for resource resolution details.
@@ -125,7 +125,7 @@ message ListCommitHistoryResponse {
   // The next page token.
   //
   /// If empty, there are no more pages.
-  string next_page_token = 1;
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The listed Commits.
   repeated Commit commits = 2;
 }

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -76,7 +76,7 @@ message ListModulesRequest {
   // The page to start from.
   //
   // If empty, the first page is returned,
-  string page_token = 2 [(buf.validate.field).string.max_len = 255];
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The specific Users or Organizations to list Modules for.
   //
   // If empty, all Modules for all owners are listed, but this functionality
@@ -88,7 +88,7 @@ message ListModulesResponse {
   // The next page token.
   //
   /// If empty, there are no more pages.
-  string next_page_token = 1 [(buf.validate.field).string.max_len = 255];
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The listed Modules.
   repeated Module modules = 2;
 }

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -68,7 +68,7 @@ message ListTagsRequest {
   // The page to start from.
   //
   // If empty, the first page is returned,
-  string page_token = 2;
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The reference to list Tags for.
   //
   // See the documentation on Ref for resource resolution details.
@@ -87,7 +87,7 @@ message ListTagsResponse {
   // The next page token.
   //
   /// If empty, there are no more pages.
-  string next_page_token = 1;
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The listed Tags.
   repeated Tag tags = 2;
 }

--- a/buf/registry/module/v1beta1/vcs_commit_service.proto
+++ b/buf/registry/module/v1beta1/vcs_commit_service.proto
@@ -55,7 +55,7 @@ message ListVCSCommitsRequest {
   // The page to start from.
   //
   // If empty, the first page is returned,
-  string page_token = 2;
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
 
   // The reference to list VCSCommits for.
   //
@@ -75,7 +75,7 @@ message ListVCSCommitsResponse {
   // The next page token.
   //
   /// If empty, there are no more pages.
-  string next_page_token = 1;
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The listed VCSCommits.
   repeated VCSCommit vcs_commits = 2;
 }

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -73,7 +73,7 @@ message ListOrganizationsRequest {
   // The page to start from.
   //
   // If empty, the first page is returned,
-  string page_token = 2 [(buf.validate.field).string.max_len = 255];
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The ids of the specific Users to list Organizations for.
   //
   // If this is empty, all Organizations are listed, but this functionality
@@ -85,7 +85,7 @@ message ListOrganizationsResponse {
   // The next page token.
   //
   /// If empty, there are no more pages.
-  string next_page_token = 1 [(buf.validate.field).string.max_len = 255];
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The listed Organizations.
   repeated Organization organizations = 2;
 }

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -73,7 +73,7 @@ message ListUsersRequest {
   // The page to start from.
   //
   // If empty, the first page is returned,
-  string page_token = 2 [(buf.validate.field).string.max_len = 255];
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The specific Organizations to list Users for.
   //
   // If this is empty, all Users for all Organizations are listed, but this functionality
@@ -85,7 +85,7 @@ message ListUsersResponse {
   // The next page token.
   //
   /// If empty, there are no more pages.
-  string next_page_token = 1 [(buf.validate.field).string.max_len = 255];
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The list of Users.
   repeated User users = 2;
 }


### PR DESCRIPTION
We wanted to either pick some arbitrary large value or remove it entirely. Others pointed out that 255 is short enough that it might be a bit too small for base64'd cursor pagination, so I picked 4096 as an arbitrary value.

The justification for this is that _removing_ validation later would be backwards compatible, but adding validation later would be backwards incompatible. So a lenient limit seems like a decent idea.

I think this is the last of the validation issues. I made a couple additional passes to make sure and didn't see anything else that obviously needed attention.

<!-- Closes BSR-2930. -->