### PR TITLE
Add ignore_empty for optional uri field validation

### DIFF
--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -62,7 +62,8 @@ message Module {
   // The configurable URL in the description of the Module,
   string url = 9 [
     (buf.validate.field).string.uri = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 255,
+    (buf.validate.field).ignore_empty = true
   ];
   // The id of the Branch which releases are generated from.
   string release_branch_id = 10 [

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -113,7 +113,8 @@ message CreateModulesRequest {
     // The configurable URL in the description of the module.
     string url = 5 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore_empty = true
     ];
     // The name of the release Branch of the module.
     //
@@ -146,7 +147,8 @@ message UpdateModulesRequest {
     // uThe configurable URL in the description of the module.
     optional string url = 6 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore_empty = true
     ];
     oneof release_branch_ref {
       // The id of the release Branch of the Module.

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -144,7 +144,7 @@ message UpdateModulesRequest {
     optional ModuleState state = 4 [(buf.validate.field).enum.defined_only = true];
     // The configurable description of the module.
     optional string description = 5 [(buf.validate.field).string.max_len = 350];
-    // uThe configurable URL in the description of the module.
+    // The configurable URL in the description of the module.
     optional string url = 6 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,

--- a/buf/registry/owner/v1beta1/organization.proto
+++ b/buf/registry/owner/v1beta1/organization.proto
@@ -49,7 +49,8 @@ message Organization {
   // The configurable URL that represents the homepage for an Organization.
   string url = 6 [
     (buf.validate.field).string.uri = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 255,
+    (buf.validate.field).ignore_empty = true
   ];
   // The verification status of the Organization.
   OrganizationVerificationStatus verification_status = 7 [

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -103,7 +103,8 @@ message CreateOrganizationsRequest {
     // The configurable URL that represents the homepage for an Organization.
     string url = 3 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore_empty = true
     ];
     // The verification status of the Organizatioh.
     //
@@ -132,7 +133,8 @@ message UpdateOrganizationsRequest {
     // The configurable URL that represents the homepage for an Organization.
     optional string url = 3 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore_empty = true
     ];
     // The verification status of the Organization.
     optional OrganizationVerificationStatus verification_status = 4 [(buf.validate.field).enum.defined_only = true];

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -59,7 +59,8 @@ message User {
   // The configurable URL that represents the homepage for a User.
   string url = 8 [
     (buf.validate.field).string.uri = true,
-    (buf.validate.field).string.max_len = 255
+    (buf.validate.field).string.max_len = 255,
+    (buf.validate.field).ignore_empty = true
   ];
   // The verification status of the User.
   UserVerificationStatus verification_status = 9 [

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -107,7 +107,8 @@ message CreateUsersRequest {
     // The configurable URL that represents the homepage for a User.
     string url = 4 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore_empty = true
     ];
     // The verification status of the User.
     //
@@ -138,7 +139,8 @@ message UpdateUsersRequest {
     // The configurable URL that represents the homepage for a User.
     optional string url = 4 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore_empty = true
     ];
     // The verification status of the User.
     optional UserVerificationStatus verification_status = 5 [(buf.validate.field).enum.defined_only = true];


### PR DESCRIPTION
Adds to all uri fields that can be optional set. Using with options still adds ignore_empty to allow unsetting the value.

Otherwise empty string "" will fail validation with: 
```
invalid_argument: validation error:
 - values[0].url: value must be a valid URI [string.uri]
```