### PR TITLE
Document DeleteUsers behavior

### DIFF
--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -47,6 +47,9 @@ service UserService {
   // Delete existing Users.
   //
   // This operation is atomic. Either all Users are deleted or an error is returned.
+  // Duplicate UserRefs are allowed, and only one User will be deleted. Likewise,
+  // duplicate UserRefs belonging to the same User, by id or name, are allowed, and
+  // only one User will be deleted.
   rpc DeleteUsers(DeleteUsersRequest) returns (DeleteUsersResponse) {
     option idempotency_level = IDEMPOTENT;
   }


### PR DESCRIPTION
Took a stab at improving the comments around the `DeleteUsers` behavior.

@emcfarlane does this make sense in terms of the implementation?

- Duplicate ids or names are deduplicated, and only one user will be deleted
- Duplicate refs that belong to the same user, id and name, are deduplicated and only one user is deleted
- Both scenarios are allowed and do not surface an error