### PR TITLE
Fix UserService/PatchUsers URL validation

### DIFF
--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -141,9 +141,11 @@ message UpdateUsersRequest {
     optional string description = 3 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for a User.
     optional string url = 4 [
-      (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore_empty = true
+      (buf.validate.field).cel = {
+        id: "string.uri",
+        expression: "this == '' || this.isUri() ? '' : 'value must be a valid URI'"
+      }
     ];
     // The verification status of the User.
     optional UserVerificationStatus verification_status = 5 [(buf.validate.field).enum.defined_only = true];


### PR DESCRIPTION
To allow unsetting the URL we must allow validation to pass on an empty string. New protovalidate [behaviour](https://github.com/bufbuild/protovalidate-go/pull/76) changes optional fields with an `ignore_empty` set to act as a no-op. Fallback to a CEL expression to validate the URL if present.