### PR TITLE
Add username validation for names

### DIFF
--- a/buf/registry/owner/v1beta1/organization.proto
+++ b/buf/registry/owner/v1beta1/organization.proto
@@ -42,7 +42,9 @@ message Organization {
   // A name uniquely identifies an Organization, however name is mutable.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 32
+    (buf.validate.field).string.min_len = 2,
+    (buf.validate.field).string.max_len = 32,
+    (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
   ];
   // The configurable description of the Organization.
   string description = 5 [(buf.validate.field).string.max_len = 350];
@@ -82,8 +84,9 @@ message OrganizationRef {
     string id = 1 [(buf.validate.field).string.uuid = true];
     // The name of the Organization.
     string name = 2 [(buf.validate.field).string = {
-      min_len: 1;
+      min_len: 2;
       max_len: 32;
+      pattern: "^[a-z][a-z0-9-]*[a-z0-9]$";
     }];
   }
 }

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -98,7 +98,9 @@ message CreateOrganizationsRequest {
     // The name of the Organization.
     string name = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 32
+      (buf.validate.field).string.min_len = 2,
+      (buf.validate.field).string.max_len = 32,
+      (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
     ];
     // The configurable description of the Organization.
     string description = 2 [(buf.validate.field).string.max_len = 350];

--- a/buf/registry/owner/v1beta1/owner.proto
+++ b/buf/registry/owner/v1beta1/owner.proto
@@ -48,8 +48,9 @@ message OwnerRef {
     string id = 1 [(buf.validate.field).string.uuid = true];
     // The name of the User or Organization.
     string name = 2 [(buf.validate.field).string = {
-      min_len: 1;
+      min_len: 2;
       max_len: 32;
+      pattern: "^[a-z][a-z0-9-]*[a-z0-9]$";
     }];
   }
 }

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -42,7 +42,9 @@ message User {
   // A name uniquely identifies a User, however name is mutable.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 32
+    (buf.validate.field).string.min_len = 2,
+    (buf.validate.field).string.max_len = 32,
+    (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
   ];
   // The type of the User.
   UserType type = 5 [
@@ -111,8 +113,9 @@ message UserRef {
     string id = 1 [(buf.validate.field).string.uuid = true];
     // The name of the User.
     string name = 2 [(buf.validate.field).string = {
-      min_len: 1;
+      min_len: 2;
       max_len: 32;
+      pattern: "^[a-z][a-z0-9-]*[a-z0-9]$";
     }];
   }
 }

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -101,7 +101,9 @@ message CreateUsersRequest {
     // The name of the User.
     string name = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 32
+      (buf.validate.field).string.min_len = 2,
+      (buf.validate.field).string.max_len = 32,
+      (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
     ];
     // The type of the User.
     //


### PR DESCRIPTION
Adds a regex pattern match for usernames "^[a-z][a-z0-9-]*[a-z0-9]$". Must start with a lowercase letter, only consist of alpha numerics or hypens and doesn't end with a hypen. Bumped the min length to 2 as the RE2 syntax doesn't support lookback syntax.

Error on failure will be:
```
validation failed: validation error:
 - name: value does not match regex pattern `^[a-z][a-z0-9-]*[a-z0-9]$` [string.pattern]
```
Should we instead use a CEL expression for better errors?
```proto
(buf.validate.field).cel = {
  id: "username",
  message: "value must start with a lowercase letter and contain only letters, numbers, or hypens and cannot end with a hypen",
  expression: "this.matches('^[a-z][a-z0-9-]*[a-z0-9]$')"
}
```
```
validation failed: validation error:
 - name: value must start with a lowercase letter, contain only letters, numbers, or hypens and cannot end with a hypen [username]
```