### PR TITLE
Extract module full name into its own message

### DIFF
--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package buf.registry.module.v1beta1;
 
+import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
@@ -80,18 +81,10 @@ message BranchRef {
   // A Name uniquely identifies a Branch.
   // This is used for requests when a caller only has the branch name and not the ID.
   message Name {
-    // The name of the User or Organization that owns the Module that contains this Branch.
-    string owner = 1 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 32
-    ];
-    // The name of the Module that contains this Branch.
-    string module = 2 [(buf.validate.field).string = {
-      min_len: 2,
-      max_len: 100
-    }];
+    // The full name of the Module that contains this Branch.
+    ModuleFullName module = 1;
     // The name of the Branch.
-    string branch = 3 [
+    string branch = 2 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.max_len = 250
     ];

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -112,7 +112,7 @@ message ModuleFullName {
 // This is used in requests.
 message ModuleRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
-  
+
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the Module.

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -91,34 +91,33 @@ enum ModuleState {
   MODULE_STATE_DEPRECATED = 2;
 }
 
+// The fully-qualified name of a Module within a BSR instance.
+//
+// A ModuleFullName uniquely identifies a Module.
+message ModuleFullName {
+  // The name of the owner of the Module, either a User or Organization.
+  string owner = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.max_len = 32
+  ];
+  // The name of the Module.
+  string module = 2 [(buf.validate.field).string = {
+    min_len: 2,
+    max_len: 100
+  }];
+}
+
 // ModuleRef is a reference to a Module, either an id or a fully-qualified name.
 //
 // This is used in requests.
 message ModuleRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
-
-  // The fully-qualified name of a Module within a BSR instance.
-  //
-  // A Name uniquely identifies a Module.
-  // This is used for requests when a caller only has the module name and not the ID.
-  message Name {
-    // The name of the owner of the Module, either a User or Organization.
-    string owner = 1 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 32
-    ];
-    // The name of the Module.
-    string module = 2 [(buf.validate.field).string = {
-      min_len: 2,
-      max_len: 100
-    }];
-  }
-
+  
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the Module.
     string id = 1 [(buf.validate.field).string.uuid = true];
     // The fully-qualified name of the Module.
-    Name name = 2;
+    ModuleFullName name = 2;
   }
 }

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package buf.registry.module.v1beta1;
 
+import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
@@ -65,30 +66,22 @@ message ResourceRef {
   // Names can only be used in requests, and only for read-only RPCs, that is
   // you should not use an arbitrary reference when modifying a specific resource.
   message Name {
-    // The name of the User or Organization that owns the resource.
-    string owner = 1 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 32
-    ];
-    // The name of the Module the contains or is the resource.
-    string module = 2 [(buf.validate.field).string = {
-      min_len: 2,
-      max_len: 100
-    }];
+    // The full name of the Module the contains or is the resource.
+    ModuleFullName module = 1;
     oneof child {
       // The name of the Branch.
-      string branch_name = 3 [(buf.validate.field).string.max_len = 250];
+      string branch_name = 2 [(buf.validate.field).string.max_len = 250];
       // The name of the Tag.
-      string tag_name = 4 [(buf.validate.field).string.max_len = 250];
+      string tag_name = 3 [(buf.validate.field).string.max_len = 250];
       // The hash of the VCSCommit.
-      string vcs_commit_hash = 5 [(buf.validate.field).string.pattern = "^[0-9a-fA-F]{40}$"];
+      string vcs_commit_hash = 4 [(buf.validate.field).string.pattern = "^[0-9a-fA-F]{40}$"];
       // The digest of the Commit.
-      buf.registry.storage.v1beta1.Digest digest = 6;
+      buf.registry.storage.v1beta1.Digest digest = 5;
       // The untyped reference, applying the semantics as documented on the Name message.
       //
       // If this value is present but empty, this should be treated as not present, that is
       // an empty value is the same as a null value.
-      string ref = 7;
+      string ref = 6;
     }
   }
 

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package buf.registry.module.v1beta1;
 
+import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
@@ -83,18 +84,10 @@ message TagRef {
   // A Name uniquely identifies a Tag.
   // This is used for requests when a caller only has the tag name and not the ID.
   message Name {
-    // The name of the owner of the Module that contains the Tag, either a User or Organization.
-    string owner = 1 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 32
-    ];
-    // The name of the Module that contains the Tag, either a User or Organization.
-    string module = 2 [(buf.validate.field).string = {
-      min_len: 2,
-      max_len: 100
-    }];
+    // The full name of the Module that contains the Tag.
+    ModuleFullName module = 1;
     // The Tag name.
-    string tag = 3 [
+    string tag = 2 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.max_len = 250
     ];

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package buf.registry.module.v1beta1;
 
+import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
@@ -112,18 +113,10 @@ message VCSCommitRef {
   // A Name uniquely identifies a VCSCommit.
   // This is used for requests when a caller only has the VCSCommit hash and not the ID.
   message Name {
-    // The name of the owner of the Module that contains the VCSCommit, either a user or organization.
-    string owner = 1 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 32
-    ];
-    // The name of the Module that contains the VCSCommit.
-    string module = 2 [(buf.validate.field).string = {
-      min_len: 2,
-      max_len: 100
-    }];
+    // The full name of the Module that contains the VCSCommit.
+    ModuleFullName module = 1;
     // The hash of the VCSCommit.
-    string hash = 3 [
+    string hash = 2 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.pattern = "^[0-9a-fA-F]{40}$"
     ];


### PR DESCRIPTION
When referencing module resources the module owner and name are always present, as well in the module ref.