### PR TITLE
Revamp CreateCommits to just create Commits and add specialized Push and Rebase endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN := .tmp/bin
 export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
 
-BUF_VERSION := 21ba19590be4afe6fa3af0406e138c4fdc36fedf
+BUF_VERSION := v1.28.1
 COPYRIGHT_YEARS := 2023
 
 .PHONY: help

--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -60,12 +60,12 @@ message Branch {
   // Only one Branch per module will be marked as the release Branch.
   // TODO: enum?
   bool is_release = 9 [(buf.validate.field).required = true];
-  // The id of the latest Commit created on the Branch.
+  // The id of the head Commit created on the Branch.
   string head_commit_id = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
-  // The Digest of the latest Commit pushed to the Branch.
+  // The Digest of the head Commit pushed to the Branch.
   buf.registry.storage.v1beta1.Digest head_commit_digest = 11 [(buf.validate.field).required = true];
 }
 

--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -61,12 +61,12 @@ message Branch {
   // TODO: enum?
   bool is_release = 9 [(buf.validate.field).required = true];
   // The id of the latest Commit created on the Branch.
-  string latest_commit_id = 10 [
+  string head_commit_id = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uuid = true
   ];
   // The Digest of the latest Commit pushed to the Branch.
-  buf.registry.storage.v1beta1.Digest latest_commit_digest = 11 [(buf.validate.field).required = true];
+  buf.registry.storage.v1beta1.Digest head_commit_digest = 11 [(buf.validate.field).required = true];
 }
 
 // BranchRef is a reference to a Branch, either an id or a fully-qualified name.

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -17,8 +17,10 @@ syntax = "proto3";
 package buf.registry.module.v1beta1;
 
 import "buf/registry/module/v1beta1/branch.proto";
+import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/module/v1beta1/resource.proto";
+import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -37,6 +39,16 @@ service BranchService {
   rpc ListBranches(ListBranchesRequest) returns (ListBranchesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // Push existing Commits onto Branches.
+  //
+  // This operation is atomic. Either all Commits are pushed to the referenced Branches or an error
+  // is returned.
+  rpc PushCommits(PushCommitsRequest) returns (PushCommitsResponse);
+  // Create or update histories for Branches.
+  //
+  // This operation is atomic. Either all Branches have their histories created/update updated or an
+  // error is returned.
+  rpc CreateOrUpdateBranchHistories(CreateOrUpdateBranchHistoriesRequest) returns (CreateOrUpdateBranchHistoriesResponse);
 }
 
 message GetBranchesRequest {
@@ -97,4 +109,108 @@ message ListBranchesResponse {
   string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
   // The listed Branches.
   repeated Branch branches = 2;
+}
+
+message PushCommitsRequest {
+  // A request to push a Commit to a Branch.
+  message Value {
+    // The Branch to push the Commit to.
+    BranchRef branch_ref = 1 [(buf.validate.field).required = true];
+    // The ID of the Commit to push to the Branch.
+    //
+    // This Commit will become the latest Commit on the Branch.
+    //
+    // If the Commit already exists on the Branch, an error is returned.
+    string commit_id = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.uuid = true
+    ];
+  }
+  // The requests to push a Commit to a Branch.
+  //
+  // Commits will be pushed to Branches in the order provided.
+  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message PushCommitsResponse {
+  message Value {
+    // The Branch to which the Commit was pushed.
+    Branch branch = 1 [(buf.validate.field).required = true];
+    // The Commit that was pushed to the Branch.
+    Commit commit = 2 [(buf.validate.field).required = true];
+  }
+  // The Branches that were pushed to, in the order of the request.
+  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message CreateOrUpdateBranchHistoriesRequest {
+  // A request to creatqe a new Branch with the expected history.
+  message CreateBranchOp {
+    // The module for which to create the Branch.
+    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
+    // The name of the branch to create.
+    string branch_name = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 250
+    ];
+    // The ID of another Commit on another Branch from which to import Branch history. The history
+    // of any Branch that contains this Commit will be imported into the newly created Branch, up to
+    // and including this Commit.
+    //
+    // This is primarily designed for use in forking a Branch from an existing Branch instead of
+    // pushing the new Branch's entire history.
+    optional string import_from_commit_id = 3 [(buf.validate.field).string.uuid = true];
+    // The IDs of Commits to add to the Branch, ordered in order in which they should be added to
+    // the Branch's history.
+    repeated string commit_ids_to_add = 4 [(buf.validate.field).string.uuid = true];
+  }
+
+  // A request to update an existing Branch's history.
+  message UpdateBranchOp {
+    // The branch to update the history of.
+    BranchRef branch_ref = 1 [(buf.validate.field).required = true];
+    // The ID of the latest Commit on the Branch.
+    //
+    // If the ID provided does not match the ID of the latest Commit on the Branch, an error is
+    // returned.
+    string latest_commit_id = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.uuid = true
+    ];
+    // The IDs of Commits to remove from the Branch, ordered in order in which they appear in the
+    // Branch's history.
+    //
+    // These commits must appear in order at the end of the Branch's history.
+    repeated string commit_ids_to_remove = 3 [(buf.validate.field).string.uuid = true];
+    // The IDs of Commits to add to the Branch, ordered in order in which they should be added to
+    // the Branch's history.
+    repeated string commit_ids_to_add = 4 [(buf.validate.field).string.uuid = true];
+  }
+
+  message Value {
+    oneof request {
+      // A request to create a new Branch with the expected history.
+      CreateBranchOp new_branch_op = 1;
+      // A request to patch the history of a Branch.
+      //
+      // After this request is successful, the history of the Branch will be:
+      // [..., head, <commits to add>].
+      UpdateBranchOp existing_branch_op = 2;
+    }
+  }
+  // The requests to update Branch histories.
+  //
+  // Branches will be created/updated in the order provided.
+  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message CreateOrUpdateBranchHistoriesResponse {
+  message Value {
+    // The Branch whose history was updated.
+    Branch branch = 1 [(buf.validate.field).required = true];
+    // The new Commits after the previous HEAD, in the order that the Commits appear in history.
+    repeated Commit commits = 3;
+  }
+  // The Branches that were updated, in the order of the request.
+  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -127,7 +127,7 @@ message PushRequest {
     //
     // The last Commit will become the head Commit on the Branch.
     //
-    // If the Commit already exists on the Branch, an error is returned.
+    // If any of these Commits already exist on the Branch, an error is returned.
     repeated string commit_ids = 2 [
       (buf.validate.field).repeated.min_items = 1,
       (buf.validate.field).repeated.items = {

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -51,7 +51,7 @@ service BranchService {
   //
   // This operation is atomic. Either all Branches are rebased as represented in the given Operations,
   // or an error is returned. Additionally, each update in the request asserts the expected head Commit
-  // of the branch. If the actual head Commit does not match the expected head COmmit, all Operations
+  // of the branch. If the actual head Commit does not match the expected head Commit, all Operations
   // are rejected and an error is returned.
   rpc Rebase(RebaseRequest) returns (RebaseResponse);
 }

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -162,7 +162,7 @@ message RebaseRequest {
         (buf.validate.field).required = true,
         (buf.validate.field).string.max_len = 250
       ];
-      // The ID of the Commit for which to start history from. The history of the branch will
+      // The ID of the Commit from which to start history. The history of the branch will
       // reflect the history as if you called ListCommitHistory for this Commit ID.
       //
       // If this is empty, the created Branch will only have the Commits specified in

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -53,7 +53,9 @@ service BranchService {
   // or an error is returned. Additionally, each update in the request asserts the expected head Commit
   // of the branch. If the actual head Commit does not match the expected head Commit, all Operations
   // are rejected and an error is returned.
-  rpc Rebase(RebaseRequest) returns (RebaseResponse);
+  rpc Rebase(RebaseRequest) returns (RebaseResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
 }
 
 message GetBranchesRequest {

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package buf.registry.module.v1beta1;
 
 import "buf/registry/module/v1beta1/branch.proto";
-import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/module/v1beta1/resource.proto";
 import "buf/validate/validate.proto";
@@ -133,9 +132,7 @@ message PushRequest {
     repeated string commit_ids = 2 [
       (buf.validate.field).repeated.min_items = 1,
       (buf.validate.field).repeated.items = {
-        string: {
-          uuid: true,
-        }
+        string: {uuid: true}
       }
     ];
   }
@@ -182,13 +179,9 @@ message RebaseRequest {
       //
       // If start_commit_id is not specified, the newly-created Branch will have exactly
       // these Commits, in this order.
-      repeated string add_commit_ids = 4 [
-        (buf.validate.field).repeated.items = {
-          string: {
-            uuid: true,
-          }
-        }
-      ];
+      repeated string add_commit_ids = 4 [(buf.validate.field).repeated.items = {
+        string: {uuid: true}
+      }];
     }
 
     // An operation to update an existing branch.
@@ -212,13 +205,9 @@ message RebaseRequest {
       // Note that it is valid to have one of the remove_commit_ids be equal to the
       // expected_head_commit_id. If this is the case, the Branch will have a different
       // head Commit that add_commit_ids will be applied to.
-      repeated string remove_commit_ids = 3 [
-        (buf.validate.field).repeated.items = {
-          string: {
-            uuid: true,
-          }
-        }
-      ];
+      repeated string remove_commit_ids = 3 [(buf.validate.field).repeated.items = {
+        string: {uuid: true}
+      }];
       // The IDs of the Commits to add to the Branch, in the order they should be added.
       //
       // These are added starting at the head Commit after remove_commit_ids has been applied.
@@ -226,13 +215,9 @@ message RebaseRequest {
       // Note that is is valid to have IDs in both add_commit_ids and remove_commit_ids. If
       // this is the case, the IDs will be removed from the Branch prior to re-adding them after
       // the head Commit via add_commit_ids.
-      repeated string add_commit_ids = 4 [
-        (buf.validate.field).repeated.items = {
-          string: {
-            uuid: true,
-          }
-        }
-      ];
+      repeated string add_commit_ids = 4 [(buf.validate.field).repeated.items = {
+        string: {uuid: true}
+      }];
     }
 
     oneof value {

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -38,17 +38,23 @@ service BranchService {
   rpc ListBranches(ListBranchesRequest) returns (ListBranchesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // Push existing Commits onto Branches.
+  // Append existing Commits onto Branches.
   //
-  // This operation is atomic. Either all Commits are pushed to the referenced Branches in the order
+  // This operation is atomic. Either all Commits are appended to the referenced Branches in the order
   // provided or an error is returned.
   //
-  // This operation does not allow the caller to assert the state of Branches before pushing any
-  // Commits onto them. As a result, multiple concurrent PushCommits operations that target the same
+  // This operation does not allow the caller to assert the state of Branches before appending any
+  // Commits onto them. As a result, multiple concurrent AppendCommits operations that target the same
   // Branch will all succeed, and the latest Commit on the Branch will be determined by the last
-  // request that succeeded. To deterministically push Commits onto a Branch, use
+  // request that succeeded. To deterministically append Commits onto a Branch, use
   // PatchBranchHistories instead.
-  rpc PushCommits(PushCommitsRequest) returns (PushCommitsResponse);
+  //
+  // As opposed to most endpoints in the registry API, the returned response Values may not be
+  // the same length as the input request Values. The returned response Values will include
+  // the unique set of Branches that were updated as part of this request. If there were
+  // multiple Commits appended to a single Branch, the length returned response Values will
+  // be less than the length of the input request Values.
+  rpc AppendCommits(AppendCommitsRequest) returns (AppendCommitsResponse);
   // Patch histories for Branches.
   //
   // This operation is atomic. Either all Branches have their histories patched or an error is
@@ -118,10 +124,9 @@ message ListBranchesResponse {
   repeated Branch branches = 2;
 }
 
-message PushCommitsRequest {
-  // A request to push a Commit to a Branch.
+message AppendCommitsRequest {
   message Value {
-    // The Branch to push the Commit to.
+    // The Branch to append the Commit to.
     BranchRef branch_ref = 1 [(buf.validate.field).required = true];
     // The ID of the Commit to push to the Branch.
     //
@@ -133,20 +138,25 @@ message PushCommitsRequest {
       (buf.validate.field).string.uuid = true
     ];
   }
-  // The requests to push a Commit to a Branch.
+  // The Commits to append with the Branches they should be appended to.
   //
-  // Commits will be pushed to Branches in the order provided.
+  // Commits will be appended to a given Branch in the order they are provided. That is
+  // [ Value<branch1,commit_id2>, Value<branch2,commit_id1>, Value<branch1, commit_id1>]
+  // will result in branch1 having commit_id2 appended first, commit_id1 appended last,
+  // and branch2 having only commit_id1 appended.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message PushCommitsResponse {
+message AppendCommitsResponse {
   message Value {
-    // The Branch to which the Commit was pushed.
+    // The updated Branch to which a Commit was appended.
     Branch branch = 1 [(buf.validate.field).required = true];
-    // The Commit that was pushed to the Branch.
-    Commit commit = 2 [(buf.validate.field).required = true];
   }
-  // The Branches that were pushed to, in the order of the request.
+  // The Branches that were appended to. This list will be the unique set of Branches
+  // that were appended to, and the length of values will be less than the length
+  // of the input request values if multiple Commits were appended to a single Branch.
+  // However, the response values will have Branches ordered in the same order that
+  // the Branches first appeared in the request.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -127,6 +127,10 @@ message ListBranchesResponse {
 message AppendCommitsRequest {
   message Value {
     // The Branch to append the Commit to.
+    //
+    // TODO: Does this branch need to already exist? If not, document, and perhaps
+    // re-evaluate naming of RPC, or (more likely) just document that non-existent
+    // branches will be created.
     BranchRef branch_ref = 1 [(buf.validate.field).required = true];
     // The ID of the Commit to push to the Branch.
     //

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -186,7 +186,7 @@ message PatchBranchHistoriesRequest {
     //
     // This is primarily designed for use in forking a Branch from an existing Branch instead of
     // providing the new Branch's entire history.
-    optional string import_from_commit_id = 3 [(buf.validate.field).string.uuid = true];
+    string import_from_commit_id = 3 [(buf.validate.field).string.uuid = true];
     // The IDs of Commits to add to the Branch, ordered in order in which they should be added to
     // the Branch's history.
     //

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -172,6 +172,10 @@ message PatchBranchHistoriesRequest {
     // The module for which to create the Branch.
     ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The name of the branch to create.
+    //
+    // TODO: Especially if we create branches via AppendCommits, why the assymmetry with
+    // using ModuleRef/branch_name here, but BranchRef in PatchBranchHistory? The answer
+    // likely comes down to "we know we don't have a Branch ID in this", but need to check.
     string branch_name = 2 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.max_len = 250

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -125,7 +125,7 @@ message PushRequest {
     BranchRef branch_ref = 1 [(buf.validate.field).required = true];
     // The ID of the Commits to push to the Branch, in the order they should be added.
     //
-    // This Commit will become the head Commit on the Branch.
+    // The last Commit will become the head Commit on the Branch.
     //
     // If the Commit already exists on the Branch, an error is returned.
     repeated string commit_ids = 2 [

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -43,7 +43,7 @@ service BranchService {
   // provided or an error is returned.
   //
   // This operation does not allow the caller to assert the state of Branches before pushing any
-  // Commits onto them. As a result, multiple concurrent PushCommits operations that target the same
+  // Commits onto them. As a result, multiple concurrent Push operations that target the same
   // Branch will all succeed, and the head Commit on the Branch will be determined by the last
   // request that succeeded. To deterministically push Commits onto a Branch, use Rebase instead.
   rpc Push(PushRequest) returns (PushResponse);

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -41,14 +41,22 @@ service BranchService {
   }
   // Push existing Commits onto Branches.
   //
-  // This operation is atomic. Either all Commits are pushed to the referenced Branches or an error
-  // is returned.
-  rpc PushCommits(PushCommitsRequest) returns (PushCommitsResponse);
-  // Create or update histories for Branches.
+  // This operation is atomic. Either all Commits are pushed to the referenced Branches in the order
+  // provided or an error is returned.
   //
-  // This operation is atomic. Either all Branches have their histories created/update updated or an
-  // error is returned.
-  rpc CreateOrUpdateBranchHistories(CreateOrUpdateBranchHistoriesRequest) returns (CreateOrUpdateBranchHistoriesResponse);
+  // This operation does not allow the caller to assert the state of Branches before pushing any
+  // Commits onto them. As a result, multiple concurrent PushCommits operations that target the same
+  // Branch will all succeed, and the latest Commit on the Branch will be determined by the last
+  // request that succeeded. To deterministically push Commits onto a Branch, use
+  // PatchBranchHistories instead.
+  rpc PushCommits(PushCommitsRequest) returns (PushCommitsResponse);
+  // Patch histories for Branches.
+  //
+  // This operation is atomic. Either all Branches have their histories patched or an error is
+  // returned. Additionally, each patch in the request asserts the expected state of the branch. If
+  // the actual state does not match the expected state, the patch is rejected and an error is
+  // returned.
+  rpc PatchBranchHistories(PatchBranchHistoriesRequest) returns (PatchBranchHistoriesResponse);
 }
 
 message GetBranchesRequest {
@@ -143,9 +151,11 @@ message PushCommitsResponse {
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message CreateOrUpdateBranchHistoriesRequest {
-  // A request to creatqe a new Branch with the expected history.
-  message CreateBranchOp {
+message PatchBranchHistoriesRequest {
+  // A request to create a new Branch with the expected history.
+  //
+  // At the end of this request, the Branch's history looks like: [...imported, ...added].
+  message CreateBranchHistory {
     // The module for which to create the Branch.
     ModuleRef module_ref = 1 [(buf.validate.field).required = true];
     // The name of the branch to create.
@@ -158,15 +168,20 @@ message CreateOrUpdateBranchHistoriesRequest {
     // and including this Commit.
     //
     // This is primarily designed for use in forking a Branch from an existing Branch instead of
-    // pushing the new Branch's entire history.
+    // providing the new Branch's entire history.
     optional string import_from_commit_id = 3 [(buf.validate.field).string.uuid = true];
     // The IDs of Commits to add to the Branch, ordered in order in which they should be added to
     // the Branch's history.
+    //
+    // If history is also being imported from another Branch (using import_from_commit_id), these
+    // Commits will be added to the Branch's history after the imported history.
     repeated string commit_ids_to_add = 4 [(buf.validate.field).string.uuid = true];
   }
 
   // A request to update an existing Branch's history.
-  message UpdateBranchOp {
+  //
+  // At the end of this request, the Branch's history looks like: [..., latest_commit, ...added].
+  message PatchBranchHistory {
     // The branch to update the history of.
     BranchRef branch_ref = 1 [(buf.validate.field).required = true];
     // The ID of the latest Commit on the Branch.
@@ -184,18 +199,21 @@ message CreateOrUpdateBranchHistoriesRequest {
     repeated string commit_ids_to_remove = 3 [(buf.validate.field).string.uuid = true];
     // The IDs of Commits to add to the Branch, ordered in order in which they should be added to
     // the Branch's history.
+    //
+    // If any Commits are referenced in commit_ids_to_remove, those Commits are removed before
+    // these Commits are added to the Branch.
     repeated string commit_ids_to_add = 4 [(buf.validate.field).string.uuid = true];
   }
 
   message Value {
     oneof request {
       // A request to create a new Branch with the expected history.
-      CreateBranchOp new_branch_op = 1;
+      CreateBranchHistory new_branch_op = 1;
       // A request to patch the history of a Branch.
       //
       // After this request is successful, the history of the Branch will be:
       // [..., head, <commits to add>].
-      UpdateBranchOp existing_branch_op = 2;
+      PatchBranchHistory existing_branch_op = 2;
     }
   }
   // The requests to update Branch histories.
@@ -204,7 +222,7 @@ message CreateOrUpdateBranchHistoriesRequest {
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message CreateOrUpdateBranchHistoriesResponse {
+message PatchBranchHistoriesResponse {
   message Value {
     // The Branch whose history was updated.
     Branch branch = 1 [(buf.validate.field).required = true];

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -184,6 +184,9 @@ message PatchBranchHistoriesRequest {
     // of any Branch that contains this Commit will be imported into the newly created Branch, up to
     // and including this Commit.
     //
+    // TODO: if Commits are on multiple Branches, how is the history between them resolved? ie
+    // how does this affect ListCommitHistory?
+    //
     // This is primarily designed for use in forking a Branch from an existing Branch instead of
     // providing the new Branch's entire history.
     string import_from_commit_id = 3 [(buf.validate.field).string.uuid = true];
@@ -219,6 +222,8 @@ message PatchBranchHistoriesRequest {
     //
     // If any Commits are referenced in commit_ids_to_remove, those Commits are removed before
     // these Commits are added to the Branch.
+    //
+    // TODO: Add starting at latest commit?
     repeated string commit_ids_to_add = 4 [(buf.validate.field).string.uuid = true];
   }
 
@@ -236,6 +241,11 @@ message PatchBranchHistoriesRequest {
   // The requests to update Branch histories.
   //
   // Branches will be created/updated in the order provided.
+  //
+  // TODO: Does this mean if I have a PatchBranchHistory that references a branch earlier created
+  // with CreateBranchHistory, that the Patch applies, or is this an error? Similarly,
+  // if I have a PatchBranchHistory that references a branch later created with CreateBranchHistory,
+  // is this an error?
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -44,16 +44,15 @@ service BranchService {
   //
   // This operation does not allow the caller to assert the state of Branches before pushing any
   // Commits onto them. As a result, multiple concurrent PushCommits operations that target the same
-  // Branch will all succeed, and the latest Commit on the Branch will be determined by the last
-  // request that succeeded. To deterministically push Commits onto a Branch, use
-  // PatchBranchHistories instead.
+  // Branch will all succeed, and the head Commit on the Branch will be determined by the last
+  // request that succeeded. To deterministically push Commits onto a Branch, use Rebase instead.
   rpc Push(PushRequest) returns (PushResponse);
   // Rebase existing Commits onto Branches.
   //
-  // This operation is atomic. Either all Branches have their histories patched or an error is
-  // returned. Additionally, each patch in the request asserts the expected state of the branch. If
-  // the actual state does not match the expected state, the patch is rejected and an error is
-  // returned.
+  // This operation is atomic. Either all Branches are rebased as represented in the given Operations,
+  // or an error is returned. Additionally, each update in the request asserts the expected head Commit
+  // of the branch. If the actual head Commit does not match the expected head COmmit, all Operations
+  // are rejected and an error is returned.
   rpc Rebase(RebaseRequest) returns (RebaseResponse);
 }
 
@@ -119,10 +118,10 @@ message ListBranchesResponse {
 
 message PushRequest {
   message Value {
-    // The Branch to push the Commit to.
+    // The Branch to push the Commits to.
     //
     // If this is a name reference, and the named Branch does not exist, it will
-    // be created and the given Commit will be the first Commit on the Branch.
+    // be created and the given Commits will be the first Commits on the Branch.
     BranchRef branch_ref = 1 [(buf.validate.field).required = true];
     // The ID of the Commits to push to the Branch, in the order they should be added.
     //
@@ -154,11 +153,11 @@ message RebaseRequest {
   message Operation {
     // An operation to create a Branch.
     message CreateBranch {
-      // The Module for which to create the Branch.
+      // The Module to create the Branch on.
       ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-      // The name of the branch to create.
+      // The name of the Branch to create.
       //
-      // If a branch with this name already exists on the Module, this will result in an error.
+      // If a Branch with this name already exists on the Module, this will result in an error.
       string branch_name = 2 [
         (buf.validate.field).required = true,
         (buf.validate.field).string.max_len = 250
@@ -185,8 +184,6 @@ message RebaseRequest {
     }
 
     // An operation to update an existing branch.
-    //
-    // At the end of this request, the Branch's history looks like: [..., latest_commit, ...added].
     message UpdateBranch {
       // The branch to update.
       BranchRef branch_ref = 1 [(buf.validate.field).required = true];

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -43,16 +43,16 @@ service BranchService {
   // provided or an error is returned.
   //
   // This operation does not allow the caller to assert the state of Branches before pushing any
-  // Commits onto them. As a result, multiple concurrent Push operations that target the same
-  // Branch will all succeed, and the head Commit on the Branch will be determined by the last
-  // request that succeeded. To deterministically push Commits onto a Branch, use Rebase instead.
+  // Commits onto them. As a result, multiple concurrent Push operations that target the same Branch
+  // will all succeed, and the head Commit on the Branch will be determined by the last request that
+  // succeeded. To deterministically push Commits onto a Branch, use Rebase instead.
   rpc Push(PushRequest) returns (PushResponse);
   // Rebase existing Commits onto Branches.
   //
-  // This operation is atomic. Either all Branches are rebased as represented in the given Operations,
-  // or an error is returned. Additionally, each update in the request asserts the expected head Commit
-  // of the branch. If the actual head Commit does not match the expected head Commit, all Operations
-  // are rejected and an error is returned.
+  // This operation is atomic. Either all Branches are rebased as represented in the given
+  // Operations, or an error is returned. Additionally, each Operation in the request asserts the
+  // expected head Commit of the branch. If the actual head Commit does not match the expected head
+  // Commit, all Operations are rejected and an error is returned.
   rpc Rebase(RebaseRequest) returns (RebaseResponse) {
     option idempotency_level = IDEMPOTENT;
   }
@@ -122,8 +122,8 @@ message PushRequest {
   message Value {
     // The Branch to push the Commits to.
     //
-    // If this is a name reference, and the named Branch does not exist, it will
-    // be created and the given Commits will be the first Commits on the Branch.
+    // If this is a name reference, and the named Branch does not exist, it will be created and the
+    // given Commits will be the first Commits on the Branch.
     BranchRef branch_ref = 1 [(buf.validate.field).required = true];
     // The ID of the Commits to push to the Branch, in the order they should be added.
     //
@@ -139,9 +139,9 @@ message PushRequest {
   }
   // The Commits to push with the Branches they should be pushed to.
   //
-  // All Values should have unique BranchRefs, that is no two Values should have
-  // a BranchRef that refers to the same Branch. An error will be returned if any
-  // two BranchRefs refer to the same Branch.
+  // All Values should have unique BranchRefs, that is no two Values should have a BranchRef that
+  // refers to the same Branch. An error will be returned if any two BranchRefs refer to the same
+  // Branch.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
@@ -164,14 +164,15 @@ message RebaseRequest {
         (buf.validate.field).required = true,
         (buf.validate.field).string.max_len = 250
       ];
-      // The ID of the Commit from which to start history. The history of the branch will
-      // reflect the history as if you called ListCommitHistory for this Commit ID.
+      // The ID of a Commit on another Branch from which to start history. The history of the branch
+      // will reflect the history as if you called ListCommitHistory for that Branch, starting at
+      // this Commit.
       //
       // If this is empty, the created Branch will only have the Commits specified in
       // add_commit_ids.
       //
-      // This is primarily designed for use in forking a Branch instead of
-      // providing the new Branch's entire history.
+      // This is primarily designed for use in forking a Branch instead of providing the new
+      // Branch's entire history.
       string base_commit_id = 3 [(buf.validate.field).string.uuid = true];
       // The IDs of the Commits to add to the Branch, in the order they should be added.
       //
@@ -201,6 +202,9 @@ message RebaseRequest {
       //
       // These Commits must appear in order at the end of the Branch's history. Commits are removed
       // from history before any Commits from add_commit_ids are added to history.
+      //
+      // Note that if all Commits on a Branch's history are specified here and add_commit_ids is
+      // empty, the resulting Branch's history is empty, and as a result the Branch is deleted.
       repeated string remove_commit_ids = 3 [(buf.validate.field).repeated.items = {
         string: {uuid: true}
       }];
@@ -236,10 +240,10 @@ message RebaseRequest {
 }
 
 message RebaseResponse {
-  // The Branches that were updated. This list will be the unique set of Branches
-  // that were updated, and the length of values will be less than the length
-  // of the input Operations if multiple Operations were applied for a single Branch.
-  // However, the response Branches ordered in the same order that the Branches
-  // first appeared in the request Operations.
+  // The Branches that were updated. This list will be the unique set of Branches that were updated.
+  // The length of branches will be less than the length of the input Operations if multiple
+  // Operations were applied for a single Branch, or if the set of Operations resulted in a Branch's
+  // deletion. However, the response Branches are ordered in the same order that the Branches first
+  // appeared in the request Operations.
   repeated Branch branches = 1 [(buf.validate.field).repeated.min_items = 1];
 }

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -170,13 +170,13 @@ message RebaseRequest {
       //
       // This is primarily designed for use in forking a Branch instead of
       // providing the new Branch's entire history.
-      string start_commit_id = 3 [(buf.validate.field).string.uuid = true];
+      string base_commit_id = 3 [(buf.validate.field).string.uuid = true];
       // The IDs of the Commits to add to the Branch, in the order they should be added.
       //
-      // If start_commit_id is specified, these will be appended to the Commit history
-      // that aleady exists up to start_commit_id.
+      // If base_commit_id is specified, these will be appended to the Commit history
+      // that aleady exists up to base_commit_id.
       //
-      // If start_commit_id is not specified, the newly-created Branch will have exactly
+      // If base_commit_id is not specified, the newly-created Branch will have exactly
       // these Commits, in this order.
       repeated string add_commit_ids = 4 [(buf.validate.field).repeated.items = {
         string: {uuid: true}

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -20,7 +20,6 @@ import "buf/registry/module/v1beta1/branch.proto";
 import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/module/v1beta1/resource.proto";
-import "buf/registry/storage/v1beta1/storage.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -38,30 +38,24 @@ service BranchService {
   rpc ListBranches(ListBranchesRequest) returns (ListBranchesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // Append existing Commits onto Branches.
+  // Push existing Commits onto Branches.
   //
-  // This operation is atomic. Either all Commits are appended to the referenced Branches in the order
+  // This operation is atomic. Either all Commits are pushed to the referenced Branches in the order
   // provided or an error is returned.
   //
-  // This operation does not allow the caller to assert the state of Branches before appending any
-  // Commits onto them. As a result, multiple concurrent AppendCommits operations that target the same
+  // This operation does not allow the caller to assert the state of Branches before pushing any
+  // Commits onto them. As a result, multiple concurrent PushCommits operations that target the same
   // Branch will all succeed, and the latest Commit on the Branch will be determined by the last
-  // request that succeeded. To deterministically append Commits onto a Branch, use
+  // request that succeeded. To deterministically push Commits onto a Branch, use
   // PatchBranchHistories instead.
-  //
-  // As opposed to most endpoints in the registry API, the returned response Values may not be
-  // the same length as the input request Values. The returned response Values will include
-  // the unique set of Branches that were updated as part of this request. If there were
-  // multiple Commits appended to a single Branch, the length returned response Values will
-  // be less than the length of the input request Values.
-  rpc AppendCommits(AppendCommitsRequest) returns (AppendCommitsResponse);
-  // Patch histories for Branches.
+  rpc Push(PushRequest) returns (PushResponse);
+  // Rebase existing Commits onto Branches.
   //
   // This operation is atomic. Either all Branches have their histories patched or an error is
   // returned. Additionally, each patch in the request asserts the expected state of the branch. If
   // the actual state does not match the expected state, the patch is rejected and an error is
   // returned.
-  rpc PatchBranchHistories(PatchBranchHistoriesRequest) returns (PatchBranchHistoriesResponse);
+  rpc Rebase(RebaseRequest) returns (RebaseResponse);
 }
 
 message GetBranchesRequest {
@@ -124,138 +118,147 @@ message ListBranchesResponse {
   repeated Branch branches = 2;
 }
 
-message AppendCommitsRequest {
+message PushRequest {
   message Value {
-    // The Branch to append the Commit to.
+    // The Branch to push the Commit to.
     //
-    // TODO: Does this branch need to already exist? If not, document, and perhaps
-    // re-evaluate naming of RPC, or (more likely) just document that non-existent
-    // branches will be created.
+    // If this is a name reference, and the named Branch does not exist, it will
+    // be created and the given Commit will be the first Commit on the Branch.
     BranchRef branch_ref = 1 [(buf.validate.field).required = true];
-    // The ID of the Commit to push to the Branch.
+    // The ID of the Commits to push to the Branch, in the order they should be added.
     //
-    // This Commit will become the latest Commit on the Branch.
+    // This Commit will become the head Commit on the Branch.
     //
     // If the Commit already exists on the Branch, an error is returned.
-    string commit_id = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.uuid = true
+    repeated string commit_ids = 2 [
+      (buf.validate.field).repeated.min_items = 1,
+      (buf.validate.field).repeated.items = {
+        string: {
+          uuid: true,
+        }
+      }
     ];
   }
-  // The Commits to append with the Branches they should be appended to.
+  // The Commits to push with the Branches they should be pushed to.
   //
-  // Commits will be appended to a given Branch in the order they are provided. That is
-  // [ Value<branch1,commit_id2>, Value<branch2,commit_id1>, Value<branch1, commit_id1> ]
-  // will result in branch1 having commit_id2 appended first, commit_id1 appended last,
-  // and branch2 having only commit_id1 appended.
+  // All Values should have unique BranchRefs, that is no two Values should have
+  // a BranchRef that refers to the same Branch. An error will be returned if any
+  // two BranchRefs refer to the same Branch.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message AppendCommitsResponse {
-  message Value {
-    // The updated Branch to which a Commit was appended.
-    Branch branch = 1 [(buf.validate.field).required = true];
-  }
-  // The Branches that were appended to. This list will be the unique set of Branches
-  // that were appended to, and the length of values will be less than the length
-  // of the input request values if multiple Commits were appended to a single Branch.
-  // However, the response values will have Branches ordered in the same order that
-  // the Branches first appeared in the request.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+message PushResponse {
+  // The Branches that were pushed to, in the order they appeared in the request.
+  repeated Branch branches = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message PatchBranchHistoriesRequest {
-  // A request to create a new Branch with the expected history.
-  //
-  // At the end of this request, the Branch's history looks like: [...imported, ...added].
-  message CreateBranchHistory {
-    // The module for which to create the Branch.
-    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-    // The name of the branch to create.
-    //
-    // TODO: Especially if we create branches via AppendCommits, why the assymmetry with
-    // using ModuleRef/branch_name here, but BranchRef in PatchBranchHistory? The answer
-    // likely comes down to "we know we don't have a Branch ID in this", but need to check.
-    string branch_name = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 250
-    ];
-    // The ID of another Commit on another Branch from which to import Branch history. The history
-    // of any Branch that contains this Commit will be imported into the newly created Branch, up to
-    // and including this Commit.
-    //
-    // TODO: if Commits are on multiple Branches, how is the history between them resolved? ie
-    // how does this affect ListCommitHistory?
-    //
-    // This is primarily designed for use in forking a Branch from an existing Branch instead of
-    // providing the new Branch's entire history.
-    string import_from_commit_id = 3 [(buf.validate.field).string.uuid = true];
-    // The IDs of Commits to add to the Branch, ordered in order in which they should be added to
-    // the Branch's history.
-    //
-    // If history is also being imported from another Branch (using import_from_commit_id), these
-    // Commits will be added to the Branch's history after the imported history.
-    repeated string commit_ids_to_add = 4 [(buf.validate.field).string.uuid = true];
-  }
-
-  // A request to update an existing Branch's history.
-  //
-  // At the end of this request, the Branch's history looks like: [..., latest_commit, ...added].
-  message PatchBranchHistory {
-    // The branch to update the history of.
-    BranchRef branch_ref = 1 [(buf.validate.field).required = true];
-    // The ID of the latest Commit on the Branch.
-    //
-    // If the ID provided does not match the ID of the latest Commit on the Branch, an error is
-    // returned.
-    string latest_commit_id = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.uuid = true
-    ];
-    // The IDs of Commits to remove from the Branch, ordered in order in which they appear in the
-    // Branch's history.
-    //
-    // These commits must appear in order at the end of the Branch's history.
-    repeated string commit_ids_to_remove = 3 [(buf.validate.field).string.uuid = true];
-    // The IDs of Commits to add to the Branch, ordered in order in which they should be added to
-    // the Branch's history.
-    //
-    // If any Commits are referenced in commit_ids_to_remove, those Commits are removed before
-    // these Commits are added to the Branch.
-    //
-    // TODO: Add starting at latest commit?
-    repeated string commit_ids_to_add = 4 [(buf.validate.field).string.uuid = true];
-  }
-
-  message Value {
-    oneof request {
-      // A request to create a new Branch with the expected history.
-      CreateBranchHistory new_branch_op = 1;
-      // A request to patch the history of a Branch.
+message RebaseRequest {
+  // An operation to apply as part of the rebase.
+  message Operation {
+    // An operation to create a Branch.
+    message CreateBranch {
+      // The Module for which to create the Branch.
+      ModuleRef module_ref = 1 [(buf.validate.field).required = true];
+      // The name of the branch to create.
       //
-      // After this request is successful, the history of the Branch will be:
-      // [..., head, <commits to add>].
-      PatchBranchHistory existing_branch_op = 2;
+      // If a branch with this name already exists on the Module, this will result in an error.
+      string branch_name = 2 [
+        (buf.validate.field).required = true,
+        (buf.validate.field).string.max_len = 250
+      ];
+      // The ID of the Commit for which to start history from. The history of the branch will
+      // reflect the history as if you called ListCommitHistory for this Commit ID.
+      //
+      // If this is empty, the created Branch will only have the Commits specified in
+      // add_commit_ids.
+      //
+      // This is primarily designed for use in forking a Branch instead of
+      // providing the new Branch's entire history.
+      string start_commit_id = 3 [(buf.validate.field).string.uuid = true];
+      // The IDs of the Commits to add to the Branch, in the order they should be added.
+      //
+      // If start_commit_id is specified, these will be appended to the Commit history
+      // that aleady exists up to start_commit_id.
+      //
+      // If start_commit_id is not specified, the newly-created Branch will have exactly
+      // these Commits, in this order.
+      repeated string add_commit_ids = 4 [
+        (buf.validate.field).repeated.items = {
+          string: {
+            uuid: true,
+          }
+        }
+      ];
+    }
+
+    // An operation to update an existing branch.
+    //
+    // At the end of this request, the Branch's history looks like: [..., latest_commit, ...added].
+    message UpdateBranch {
+      // The branch to update.
+      BranchRef branch_ref = 1 [(buf.validate.field).required = true];
+      // The ID of the Commit that the caller expects to be the head Commit on the Branch.
+      //
+      // If this ID does not match the ID of the head Commit on the Branch, an error is
+      // returned.
+      string expected_head_commit_id = 2 [
+        (buf.validate.field).required = true,
+        (buf.validate.field).string.uuid = true
+      ];
+      // The IDs of the Commits to remove from the Branch.
+      //
+      // Commits are removed before any Commits are added from add_commit_ids.
+      //
+      // Note that it is valid to have one of the remove_commit_ids be equal to the
+      // expected_head_commit_id. If this is the case, the Branch will have a different
+      // head Commit that add_commit_ids will be applied to.
+      repeated string remove_commit_ids = 3 [
+        (buf.validate.field).repeated.items = {
+          string: {
+            uuid: true,
+          }
+        }
+      ];
+      // The IDs of the Commits to add to the Branch, in the order they should be added.
+      //
+      // These are added starting at the head Commit after remove_commit_ids has been applied.
+      //
+      // Note that is is valid to have IDs in both add_commit_ids and remove_commit_ids. If
+      // this is the case, the IDs will be removed from the Branch prior to re-adding them after
+      // the head Commit via add_commit_ids.
+      repeated string add_commit_ids = 4 [
+        (buf.validate.field).repeated.items = {
+          string: {
+            uuid: true,
+          }
+        }
+      ];
+    }
+
+    oneof value {
+      option (buf.validate.oneof).required = true;
+      // Create a new branch.
+      CreateBranch create_branch = 1;
+      // Update an existing branch.
+      UpdateBranch patch_branch = 2;
     }
   }
-  // The requests to update Branch histories.
+
+  // The operations to apply.
   //
-  // Branches will be created/updated in the order provided.
-  //
-  // TODO: Does this mean if I have a PatchBranchHistory that references a branch earlier created
-  // with CreateBranchHistory, that the Patch applies, or is this an error? Similarly,
-  // if I have a PatchBranchHistory that references a branch later created with CreateBranchHistory,
-  // is this an error?
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  // The Operations will be applied in the order they are provided. Notably, this means that
+  // if a CreateBranch Operation precedes a UpdateBranch Operation for the same Branch, the
+  // UpdateBranch Operation is applied to the newly-created Branch, including any new Commits
+  // that were added from the CreateBranch Operation. Conversely, if a UpdateBranch Operation
+  // precedes the CreateBranch operation that creates the Branch, this will result in an error.
+  repeated Operation operations = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
-message PatchBranchHistoriesResponse {
-  message Value {
-    // The Branch whose history was updated.
-    Branch branch = 1 [(buf.validate.field).required = true];
-    // The new Commits after the previous HEAD, in the order that the Commits appear in history.
-    repeated Commit commits = 3;
-  }
-  // The Branches that were updated, in the order of the request.
-  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+message RebaseResponse {
+  // The Branches that were updated. This list will be the unique set of Branches
+  // that were updated, and the length of values will be less than the length
+  // of the input Operations if multiple Operations were applied for a single Branch.
+  // However, the response Branches ordered in the same order that the Branches
+  // first appeared in the request Operations.
+  repeated Branch branches = 1 [(buf.validate.field).repeated.min_items = 1];
 }

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -145,7 +145,7 @@ message AppendCommitsRequest {
   // The Commits to append with the Branches they should be appended to.
   //
   // Commits will be appended to a given Branch in the order they are provided. That is
-  // [ Value<branch1,commit_id2>, Value<branch2,commit_id1>, Value<branch1, commit_id1>]
+  // [ Value<branch1,commit_id2>, Value<branch2,commit_id1>, Value<branch1, commit_id1> ]
   // will result in branch1 having commit_id2 appended first, commit_id1 appended last,
   // and branch2 having only commit_id1 appended.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];

--- a/buf/registry/module/v1beta1/branch_service.proto
+++ b/buf/registry/module/v1beta1/branch_service.proto
@@ -197,11 +197,8 @@ message RebaseRequest {
       ];
       // The IDs of the Commits to remove from the Branch.
       //
-      // Commits are removed before any Commits are added from add_commit_ids.
-      //
-      // Note that it is valid to have one of the remove_commit_ids be equal to the
-      // expected_head_commit_id. If this is the case, the Branch will have a different
-      // head Commit that add_commit_ids will be applied to.
+      // These Commits must appear in order at the end of the Branch's history. Commits are removed
+      // from history before any Commits from add_commit_ids are added to history.
       repeated string remove_commit_ids = 3 [(buf.validate.field).repeated.items = {
         string: {uuid: true}
       }];
@@ -222,7 +219,7 @@ message RebaseRequest {
       // Create a new branch.
       CreateBranch create_branch = 1;
       // Update an existing branch.
-      UpdateBranch patch_branch = 2;
+      UpdateBranch update_branch = 2;
     }
   }
 

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -209,9 +209,9 @@ message CreateCommitsRequest {
     repeated buf.registry.storage.v1beta1.Blob missing_blobs = 2;
     // Associated VCS commit information.
     //
-    // If there is already a VCSCommit on the associated Module with a given hash, this
+    // If there are already VCSCommits on the associated Module with a given hash, this
     // will result in an error. Otherwise, a new VCSCommit is created.
-    AssociatedVCSCommit associated_vcs_commit = 5;
+    repeated AssociatedVCSCommit associated_vcs_commits = 3;
   }
   // The requests to create Commits.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -78,9 +78,11 @@ message ResolveCommitsRequest {
   //   - If a Commit is referenced, this just references that specific commit.
   //   - If a Tag is referenced, this is interpreted to mean the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, this is interpreted to mean the Commit associated with the VCSCommit.
-  //   - Is a Branch is referenced, this is interpreted to mean the latest Commit on the Branch.
+  //   - Is a Branch is referenced, this is interpreted to mean the head Commit on the Branch.
   //   - If a Digest is referenced, this is interpreted to mean the latest released Commit that has this Digest.
   //     Digests referencing unreleased Commits cannot be referenced.
+  //
+  // TODO: what is "latest released Commit" if we now have "head Commit"?
   repeated ResourceRef resource_refs = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
@@ -110,9 +112,11 @@ message ListCommitHistoryRequest {
   //   - If a Commit is referenced, history is started at this Commit.
   //   - If a Tag is referenced, history is started at the Commit associated with the Tag.
   //   - If a VCSCommit is referenced, history is started at the Commit associated with the VCSCommit.
-  //   - Is a Branch is referenced, history is started at the latest Commit on the Branch.
+  //   - Is a Branch is referenced, history is started at the head Commit on the Branch.
   //   - If a Digest is referenced, history is started at the latest released Commit that has this Digest.
   //     Digests referencing unreleased Commits cannot be referenced.
+  //
+  // TODO: what is "latest released Commit" if we now have "head Commit"?
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
   // Only return Commits that have one or more associated Tags.
   bool has_tag = 4;
@@ -236,9 +240,11 @@ message GetCommitNodesRequest {
     //   - If a Commit is referenced, files are returned from this Commit.
     //   - If a Tag is referenced, files are returned from the Commit associated with the Tag.
     //   - If a VCSCommit is referenced, files are returned from the Commit associated with the VCSCommit.
-    //   - Is a Branch is referenced, files are returned from the latest Commit on the Branch.
+    //   - Is a Branch is referenced, files are returned from the head Commit on the Branch.
     //   - If a Digest is referenced, files are returned from the latest released Commit that has this Digest.
     //     Digests referencing unreleased Commits cannot be referenced.
+    //
+    // TODO: what is "latest released Commit" if we now have "head Commit"?
     ResourceRef resource_ref = 1 [(buf.validate.field).required = true];
     // Specific file paths to retrieve.
     //

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -38,7 +38,7 @@ service CommitService {
   // Create commits on a Module with associated Content.
   //
   // These commits will not be associated with any Branch or Tag after the completion of
-  // this operation. To associate created Commits, use PushCommits or PatchBranchHistories.
+  // this operation. To associate created Commits, use BranchService.Push or BranchService.Rebase.
   //
   // This operation is atomic. Either all Commits and associated content are created or an error is returned.
   rpc CreateCommits(CreateCommitsRequest) returns (CreateCommitsResponse) {

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -41,9 +41,7 @@ service CommitService {
   // this operation. To associate created Commits, use BranchService.Push or BranchService.Rebase.
   //
   // This operation is atomic. Either all Commits and associated content are created or an error is returned.
-  rpc CreateCommits(CreateCommitsRequest) returns (CreateCommitsResponse) {
-    option idempotency_level = IDEMPOTENT;
-  }
+  rpc CreateCommits(CreateCommitsRequest) returns (CreateCommitsResponse);
   // Get the pointers to the content for a given set of Commits, Modules, Branches, Tags, or VCSCommits.
   //
   // Nodes consist of:

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -37,11 +37,10 @@ service CommitService {
   }
   // Create commits on a Module with associated Content.
   //
-  // This is used by push and sync.
+  // These commits will not be associated with any Branch or Tag after the completion of
+  // this operation. To associate created Commits, use PushCommits or PatchBranchHistories.
   //
   // This operation is atomic. Either all Commits and associated content are created or an error is returned.
-  //
-  // TODO: PushCommits? Something else? This is creating potentially a bunch of resources.
   rpc CreateCommits(CreateCommitsRequest) returns (CreateCommitsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
@@ -199,22 +198,22 @@ message CreateCommitsRequest {
     // Each ModuleNode must have a unique ModuleRef.
     // A commit will be created for each ModuleNode.
     repeated ModuleNode module_nodes = 1 [(buf.validate.field).repeated.min_items = 1];
-    // Blobs for the FileNodes referenced by module_nodes that are not present on the server.
-    //
-    // Only Blobs that were returned as missing from GetMissingBlobDigests need to be sent.
-    // Other Blobs already exist on the server, and will be ignored.
-    //
-    // If a FileNode within module_nodes has a Blob that is not on the server, and is not
-    // within missing_blobs, an error will be returned.
-    repeated buf.registry.storage.v1beta1.Blob missing_blobs = 2;
     // Associated VCS commit information.
     //
     // If there are already VCSCommits on the associated Module with a given hash, this
     // will result in an error. Otherwise, a new VCSCommit is created.
-    repeated AssociatedVCSCommit associated_vcs_commits = 3;
+    repeated AssociatedVCSCommit associated_vcs_commits = 2;
   }
   // The requests to create Commits.
   repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
+  // Blobs for the FileNodes referenced by file_nodes that are not present on the server.
+  //
+  // Only Blobs that were returned as missing from GetMissingBlobDigests need to be sent.
+  // Other Blobs already exist on the server, and will be ignored.
+  //
+  // If a FileNode has a Blob that is not on the server, and is not
+  // within missing_blobs, an error will be returned.
+  repeated buf.registry.storage.v1beta1.Blob missing_blobs = 2;
 }
 
 message CreateCommitsResponse {

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -193,41 +193,28 @@ message CreateCommitsRequest {
     repeated DepNode dep_nodes = 3;
   }
 
-  // The pointers to the content for the Modules that should have Commits created for them.
-  //
-  // Each ModuleNode must have a unique ModuleRef.
-  // A commit will be created for each ModuleNode.
-  repeated ModuleNode module_nodes = 1 [(buf.validate.field).repeated.min_items = 1];
-  // Blobs for the FileNodes referenced by module_nodes that are not present on the server.
-  //
-  // Only Blobs that were returned as missing from GetMissingBlobDigests need to be sent.
-  // Other Blobs already exist on the server, and will be ignored.
-  //
-  // If a FileNode within module_nodes has a Blob that is not on the server, and is not
-  // within missing_blobs, an error will be returned.
-  repeated buf.registry.storage.v1beta1.Blob missing_blobs = 2;
-  // The names of Branches that should be associated with this Commit.
-  //
-  // If a Branch currently exists on the associated Module with a name, this existing
-  // Branch will be used. Otherwise, a new Branch will be created for the corresponding name.
-  //
-  // If empty, the default branch is assumed as the only branch.
-  repeated string branch_names = 3 [(buf.validate.field).repeated.items = {
-    string: {max_len: 250}
-  }];
-  // The names of Tags that should be associated with this Commit.
-  //
-  // If a Tag currently exists on the assocated Module with a name, the RPC will error, however
-  // this will change in the future when we allow Tags to move. If the Tag does not
-  // currently exist, a new Tag will be created for each name.
-  repeated string tag_names = 4 [(buf.validate.field).repeated.items = {
-    string: {max_len: 250}
-  }];
-  // Associated VCS commit information.
-  //
-  // If there are already VCSCommits on the associated Module with a given hash, this
-  // will result in an error. Otherwise, a new VCSCommit is created.
-  repeated AssociatedVCSCommit associated_vcs_commits = 5;
+  message Value {
+    // The pointers to the content for the Modules that should have Commits created for them.
+    //
+    // Each ModuleNode must have a unique ModuleRef.
+    // A commit will be created for each ModuleNode.
+    repeated ModuleNode module_nodes = 1 [(buf.validate.field).repeated.min_items = 1];
+    // Blobs for the FileNodes referenced by module_nodes that are not present on the server.
+    //
+    // Only Blobs that were returned as missing from GetMissingBlobDigests need to be sent.
+    // Other Blobs already exist on the server, and will be ignored.
+    //
+    // If a FileNode within module_nodes has a Blob that is not on the server, and is not
+    // within missing_blobs, an error will be returned.
+    repeated buf.registry.storage.v1beta1.Blob missing_blobs = 2;
+    // Associated VCS commit information.
+    //
+    // If there is already a VCSCommit on the associated Module with a given hash, this
+    // will result in an error. Otherwise, a new VCSCommit is created.
+    AssociatedVCSCommit associated_vcs_commit = 5;
+  }
+  // The requests to create Commits.
+  repeated Value values = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
 message CreateCommitsResponse {


### PR DESCRIPTION
There are two things going on in this PR:

1. `CreateCommits` is updated so that it simply creates Commits for Modules without pushing them onto any Branch or assigning any Tags to them. 
   - The idea is that Commits can be "uploaded" to the BSR before they are placed in their correct places in Branch history or assigned Tags. This is very useful for `sync`, where potentially 1000s of Commits need to be created before pushing them on a Branch. Because Branch history should be patched atomically and with a lock, creating Commits in-band becomes untenable.
   - These Commits can only be referenced by their `ID`, `Digest`, or a `VCSCommitRef` if there was any `AssociatedVCSCommit`.
2. Two new RPCs are added to mutate a `Branch`'s history: `BranchService.Push` and `BranchService.Rebase`.
     - `Push` provides no assertions on the final state of a `Branch`'s history. This is the model that `buf push` currently uses, where all concurrent writes win, but the last write is king and becomes the latest commit.
     - `Rebase` allows the caller to assert on the final state of a `Branch`'s history. Concurrent writes are idempotent as long as they assert the same final state. If they don't, the first write wins and all others lose. This is the model that `buf sync` will use.