### PR TITLE
Add filtering options for ListRequestUsers

### DIFF
--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -115,12 +115,12 @@ message ListCommitHistoryRequest {
   //   - If a Digest is referenced, history is started at the latest released Commit that has this Digest.
   //     Digests referencing unreleased Commits cannot be referenced.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
+  // Whether to sort the Commits in descending order.
+  bool sort_desc = 4;
   // Only return Commits that have one or more associated Tags.
-  bool has_tag = 4;
+  bool has_tag = 5;
   // Only return Commits that have one or more associated VCSCommits.
-  bool has_vcs_commit = 5;
-  // Whether to sory the Commits in descending order.
-  bool sort_desc = 6;
+  bool has_vcs_commit = 6;
 }
 
 message ListCommitHistoryResponse {

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -84,6 +84,10 @@ message ListUsersRequest {
   repeated OrganizationRef organization_refs = 3;
   // Whether to sort the Users in descending order.
   bool sort_desc = 4;
+  // Only return Users of these types.
+  repeated UserType has_types = 5 [(buf.validate.field).enum.defined_only = true];
+  // Only return Users of these states.
+  repeated UserState has_states = 6 [(buf.validate.field).enum.defined_only = true];
 }
 
 message ListUsersResponse {


### PR DESCRIPTION
Adds two new filtering options for `UserService/ListRequestUsers`:
- `has_types`: only return users of types.
- `has_states`: only return users of states.

Required behaviour for API consumers.