### PR TITLE
Update `Commit.id` to not validate as a UUID

### DIFF
--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -61,7 +61,10 @@ message Branch {
   // TODO: enum?
   bool is_release = 9 [(buf.validate.field).required = true];
   // The id of the latest Commit created on the Branch.
-  string latest_commit_id = 10 [(buf.validate.field).required = true];
+  string latest_commit_id = 10 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.pattern = "^[0-9a-fA-F]{32}$"
+  ];
   // The Digest of the latest Commit pushed to the Branch.
   buf.registry.storage.v1beta1.Digest latest_commit_digest = 11 [(buf.validate.field).required = true];
 }

--- a/buf/registry/module/v1beta1/branch.proto
+++ b/buf/registry/module/v1beta1/branch.proto
@@ -61,10 +61,7 @@ message Branch {
   // TODO: enum?
   bool is_release = 9 [(buf.validate.field).required = true];
   // The id of the latest Commit created on the Branch.
-  string latest_commit_id = 10 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.uuid = true
-  ];
+  string latest_commit_id = 10 [(buf.validate.field).required = true];
   // The Digest of the latest Commit pushed to the Branch.
   buf.registry.storage.v1beta1.Digest latest_commit_digest = 11 [(buf.validate.field).required = true];
 }

--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -30,10 +30,7 @@ message Commit {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
   // The id of the Commit.
-  string id = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.uuid = true
-  ];
+  string id = 1 [(buf.validate.field).required = true];
   // The time the Commit was pushed to the BSR.
   //
   // Commits are immutable, so there is no corresponding update_time.

--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -30,7 +30,10 @@ message Commit {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
   // The id of the Commit.
-  string id = 1 [(buf.validate.field).required = true];
+  string id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.pattern = "^[0-9a-fA-F]{32}$"
+  ];
   // The time the Commit was pushed to the BSR.
   //
   // Commits are immutable, so there is no corresponding update_time.

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -95,7 +95,7 @@ message ResourceRef {
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the resource.
-    string id = 1 [(buf.validate.field).string.uuid = true];
+    string id = 1;
     // The fully-qualified name of the resource.
     Name name = 2;
   }

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -95,7 +95,7 @@ message ResourceRef {
   oneof value {
     option (buf.validate.oneof).required = true;
     // The id of the resource.
-    string id = 1;
+    string id = 1 [(buf.validate.field).string.pattern = "^([0-9a-fA-F]{32})|([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"];
     // The fully-qualified name of the resource.
     Name name = 2;
   }

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -59,7 +59,10 @@ message Tag {
     (buf.validate.field).string.uuid = true
   ];
   // The id of the Commit associated with the Tag.
-  string commit_id = 7 [(buf.validate.field).required = true];
+  string commit_id = 7 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.pattern = "^[0-9a-fA-F]{32}$"
+  ];
   // The Digest of the Commit associated with the Tag.
   buf.registry.storage.v1beta1.Digest commit_digest = 8 [(buf.validate.field).required = true];
   // The id of the User that last updated this Tag on the BSR.

--- a/buf/registry/module/v1beta1/tag.proto
+++ b/buf/registry/module/v1beta1/tag.proto
@@ -59,10 +59,7 @@ message Tag {
     (buf.validate.field).string.uuid = true
   ];
   // The id of the Commit associated with the Tag.
-  string commit_id = 7 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.uuid = true
-  ];
+  string commit_id = 7 [(buf.validate.field).required = true];
   // The Digest of the Commit associated with the Tag.
   buf.registry.storage.v1beta1.Digest commit_digest = 8 [(buf.validate.field).required = true];
   // The id of the User that last updated this Tag on the BSR.

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -105,7 +105,10 @@ message CreateTagsRequest {
       (buf.validate.field).string.max_len = 250
     ];
     // The id of the Commit associated with the Tag.
-    string commit_id = 3 [(buf.validate.field).required = true];
+    string commit_id = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.pattern = "^[0-9a-fA-F]{32}$"
+    ];
   }
   // The Tags to create.
   repeated Value values = 1 [

--- a/buf/registry/module/v1beta1/tag_service.proto
+++ b/buf/registry/module/v1beta1/tag_service.proto
@@ -105,10 +105,7 @@ message CreateTagsRequest {
       (buf.validate.field).string.max_len = 250
     ];
     // The id of the Commit associated with the Tag.
-    string commit_id = 3 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).string.uuid = true
-    ];
+    string commit_id = 3 [(buf.validate.field).required = true];
   }
   // The Tags to create.
   repeated Value values = 1 [

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -65,7 +65,10 @@ message VCSCommit {
     (buf.validate.field).enum.defined_only = true
   ];
   // The id of the Commit associated with the VCSCommit.
-  string commit_id = 8 [(buf.validate.field).required = true];
+  string commit_id = 8 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.pattern = "^[0-9a-fA-F]{32}$"
+  ];
   // The Digest of the Commit associated with the VCSCommit.
   buf.registry.storage.v1beta1.Digest commit_digest = 9 [(buf.validate.field).required = true];
   // The URL of of the repository on the VCS.

--- a/buf/registry/module/v1beta1/vcs_commit.proto
+++ b/buf/registry/module/v1beta1/vcs_commit.proto
@@ -65,10 +65,7 @@ message VCSCommit {
     (buf.validate.field).enum.defined_only = true
   ];
   // The id of the Commit associated with the VCSCommit.
-  string commit_id = 8 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.uuid = true
-  ];
+  string commit_id = 8 [(buf.validate.field).required = true];
   // The Digest of the Commit associated with the VCSCommit.
   buf.registry.storage.v1beta1.Digest commit_digest = 9 [(buf.validate.field).required = true];
   // The URL of of the repository on the VCS.


### PR DESCRIPTION
`Commit.id` <=> `RepositoryCommit.name`, which is a dashless UUID.

This also implies that `ResourceRef.value.id` is not a UUID.

TODO:
- [ ] This is now inconsistent across the API surface. Should we drop the UUID validation on all IDs? Ideally our IDs are opaque to users and we are not expressing their shape in the API. Alternatively, we add `Commit.name` back and `Commit.id` <=> `RepositoryCommit.id` and `Commit.name` <=> `RepositoryCommit.name`.