### PR TITLE
Fix owners ListUsers request validations

### DIFF
--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -85,9 +85,15 @@ message ListUsersRequest {
   // Whether to sort the Users in descending order.
   bool sort_desc = 4;
   // Only return Users of these types.
-  repeated UserType has_types = 5 [(buf.validate.field).enum.defined_only = true];
+  repeated UserType has_types = 5 [
+    (buf.validate.field).repeated.unique = true,
+    (buf.validate.field).repeated.items.enum.defined_only = true
+  ];
   // Only return Users of these states.
-  repeated UserState has_states = 6 [(buf.validate.field).enum.defined_only = true];
+  repeated UserState has_states = 6 [
+    (buf.validate.field).repeated.unique = true,
+    (buf.validate.field).repeated.items.enum.defined_only = true
+  ];
 }
 
 message ListUsersResponse {


### PR DESCRIPTION
Invalid field validation for lists. Fix the validation syntax to use the `repeated` selector. Also added a `unique` constraint as for filtering only unique values should be present.