### PR TITLE
Set create_by_user_id on Commit to optional

### DIFF
--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -60,10 +60,7 @@ message Commit {
   // caching of returned Commit messages if you require different DigestTypes.
   Digest digest = 5 [(buf.validate.field).required = true];
   // The id of the User that created this Commit on the BSR.
-  string created_by_user_id = 6 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.uuid = true
-  ];
+  string created_by_user_id = 6 [(buf.validate.field).string.uuid = true];
   // The URL of the source control commit that is associated with the Commit.
   //
   // BSR users can navigate to this link to find source control information that is relevant to this Commit

--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -60,6 +60,8 @@ message Commit {
   // caching of returned Commit messages if you require different DigestTypes.
   Digest digest = 5 [(buf.validate.field).required = true];
   // The id of the User that created this Commit on the BSR.
+  //
+  // May be empty if the User is no longer available.
   string created_by_user_id = 6 [(buf.validate.field).string.uuid = true];
   // The URL of the source control commit that is associated with the Commit.
   //


### PR DESCRIPTION
On user deletion `create_by_user_id` is no longer available. Remove the required option from the validation.