### PR TITLE
Default to descending order for ListLabels and ListLabelsHistory

### DIFF
--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -74,10 +74,10 @@ message ListLabelsRequest {
   // The list order.
   enum Order {
     ORDER_UNSPECIFIED = 0;
-    // Order by create_time newest to oldest.
-    ORDER_CREATE_TIME_DESC = 1;
     // Order by create_time oldest to newest.
-    ORDER_CREATE_TIME_ASC = 2;
+    ORDER_CREATE_TIME_ASC = 1;
+    // Order by create_time newest to oldest.
+    ORDER_CREATE_TIME_DESC = 2;
   }
   // The maximum number of items to return.
   //
@@ -98,8 +98,9 @@ message ListLabelsRequest {
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
   // The order to return the Labels.
   //
-  // If not specified, defaults to ORDER_CREATE_TIME_DESC.
+  // If not specified, defaults to ORDER_CREATE_TIME_ASC.
   //
+  // TODO: Do we want ORDER_CREATE_TIME_ASC to be the default?
   // TODO: We are purposefully not making the default the zero enum value, however
   // we may want to consider this.
   Order order = 4;

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -74,10 +74,10 @@ message ListLabelsRequest {
   // The list order.
   enum Order {
     ORDER_UNSPECIFIED = 0;
-    // Order by create_time oldest to newest.
-    ORDER_CREATE_TIME_ASC = 1;
     // Order by create_time newest to oldest.
-    ORDER_CREATE_TIME_DESC = 2;
+    ORDER_CREATE_TIME_DESC = 1;
+    // Order by create_time oldest to newest.
+    ORDER_CREATE_TIME_ASC = 2;
   }
   // The maximum number of items to return.
   //
@@ -98,9 +98,8 @@ message ListLabelsRequest {
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
   // The order to return the Labels.
   //
-  // If not specified, defaults to ORDER_CREATE_TIME_ASC.
+  // If not specified, defaults to ORDER_CREATE_TIME_DESC.
   //
-  // TODO: Do we want ORDER_CREATE_TIME_ASC to be the default?
   // TODO: We are purposefully not making the default the zero enum value, however
   // we may want to consider this.
   Order order = 4;
@@ -140,9 +139,8 @@ message ListLabelHistoryRequest {
   LabelRef label_ref = 3 [(buf.validate.field).required = true];
   // The order to list the Labels.
   //
-  // By default, ORDER_DESC is used.
+  // If not specified, defaults to ORDER_DESC.
   //
-  // TODO: Do we want ORDER_DESC to be the default?
   // TODO: We are purposefully not making the default the zero enum value, however
   // we may want to consider this.
   Order order = 4;


### PR DESCRIPTION
Removed TODO on ListLabelsHistoryRequest because we definitely want the default to be descending. That is the common use case, and we just had [an actual bug](https://github.com/bufbuild/core/pull/13621) in the BSR because the default didn't do something useful in the v1alpha1 equivalent of this API.