### PR TITLE
Update docs

### DIFF
--- a/buf/registry/module/v1beta1/graph_service.proto
+++ b/buf/registry/module/v1beta1/graph_service.proto
@@ -45,6 +45,9 @@ message GetGraphRequest {
   //   - If a Module is referenced, the Commit of the default Label is included.
   //   - If a Label is referenced, the Commit of this Label is included.
   //   - If a Commit is referenced, the Commit is included.
+  //
+  // The specified ResourceRefs must reference unique Modules, that is no two ResourceRefs
+  // may resolve to the same Module.
   repeated ResourceRef resource_refs = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -48,7 +48,7 @@ message ResourceRef {
   //     - If an id, this is equivalent to setting the id field on ResourceRef. However,
   //       backends can choose to validate that the owner and module fields match the resource
   //       referenced, as additional validation.
-  //     - If a name, this is interpreted to be a Label name.
+  //     - If a name, this is interpreted to be a Label name or an ID of a Commit without any dashes.
   //     - If there is a conflict between names across resources (for example, there is a Commit id
   //       and Label name of the same value), the following order of precedence is applied:
   //       - Commit


### PR DESCRIPTION
- Update `ResourceRef` to handle dashless commit IDs.
- Clarify that `GetGraph` requires unique module references.