### PR TITLE
CreateOrUpdateLabels* becomes CreateLabels*

### DIFF
--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -38,13 +38,11 @@ service LabelService {
   rpc ListLabelHistory(ListLabelHistoryRequest) returns (ListLabelHistoryResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // Create or update Labels on a Module.
+  // Create Labels on a Module.
   //
-  // If the Label does not exist, it will be created.
-  // If the Label was archived, it will be unarchived.
-  //
-  // This operation is atomic. Either all Labels are created/updated or an error is returned.
-  rpc CreateOrUpdateLabels(CreateOrUpdateLabelsRequest) returns (CreateOrUpdateLabelsResponse) {
+  // This operation is atomic. Either all Labels are created or an error is returned.
+  // It will return an error if a Label already exists.
+  rpc CreateLabels(CreateLabelsRequest) returns (CreateLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
   // Archive existing Labels.
@@ -163,15 +161,12 @@ message ListLabelHistoryResponse {
   repeated Commit commits = 2;
 }
 
-message CreateOrUpdateLabelsRequest {
-  // An individual request to create or update a Label.
+message CreateLabelsRequest {
+  // An individual request to create a Label.
   message Value {
-    // The Labels to create or update.
+    // The Labels to create.
     LabelRef label_ref = 1 [(buf.validate.field).required = true];
     // The id of the Commit to associate with the Label.
-    //
-    // If the Label already existed, the Label will now point to this Commit.
-    // If the Label was archived, it will be unarchived.
     string commit_id = 2 [
       (buf.validate.field).required = true,
       (buf.validate.field).string.uuid = true
@@ -184,8 +179,8 @@ message CreateOrUpdateLabelsRequest {
   ];
 }
 
-message CreateOrUpdateLabelsResponse {
-  // The created or updated Labels in the same order as given on the request.
+message CreateLabelsResponse {
+  // The created Labels in the same order as given on the request.
   repeated Label labels = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 


### PR DESCRIPTION
Our dependency resolution algorithm prefers to select commits by the latest creation date, but that yields non-sensical results if we allow labels to get updated to point to older commits (which the current API permits).

For example, it is currently possible to use CreateOrUpdateLabels to construct a label history like [C1, C2, C1]. Semantically C1 should be the "latest" commit, but since it has a timestamp older than C2, our dependency resolution algorithm would prefer C2.

To avoid this scenario, we should not expose an endpoint to explicitly update the commit a label is pointing to. Instead, the only way to update a label is to use UploadService. This allows users to push the content they want to push (which can be identical content to a previous commit) and we can mint a new commit for them with a current created_at timestamp. In other words, the commit history from the example above would be [C1, C2, C3] where the content of C3 is identical to the content of C1.

The alternative to this is to keep the current API but document it as being an error to attempt to update a label to point to a commit with a created_at timestamp that is earlier than the existing commit the label points to. This alternative is implemented here: https://github.com/bufbuild/registry-proto/pull/66