### PR TITLE
Add buf.registry.legacy.federation.v1beta1 package

### DIFF
--- a/buf/registry/legacy/federation/v1beta1/doc.proto
+++ b/buf/registry/legacy/federation/v1beta1/doc.proto
@@ -1,0 +1,22 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// This package is only needed due to a legacy federation feature that only remains
+// enabled on the clusters of a few of Buf's customers. If you are not one of
+// these customers, you should not use this package.
+package buf.registry.legacy.federation.v1beta1;
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/legacy/federation/v1beta1";

--- a/buf/registry/legacy/federation/v1beta1/graph.proto
+++ b/buf/registry/legacy/federation/v1beta1/graph.proto
@@ -14,22 +14,42 @@
 
 syntax = "proto3";
 
-package buf.registry.module.v1beta1;
+package buf.registry.legacy.federation.v1beta1;
 
 import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
-option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/legacy/federation/v1beta1";
 
-// A dependency graph.
+// A dependency graph that allows for federation.
+//
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
 message Graph {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
+  // A Commit in the dependency graph.
+  //
+  // This wraps the top-level Commit.
+  message Commit {
+    // The top-level Commit.
+    buf.registry.module.v1beta1.Commit commit = 1 [(buf.validate.field).required = true];
+    // The registry hostname of the Commit.
+    string registry = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.hostname = true
+    ];
+  }
   // A node in the dependency graph.
   message Node {
     // The commit of the node.
     string commit_id = 1 [(buf.validate.field).required = true];
+    // The registry hostname of the Node.
+    string registry = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.hostname = true
+    ];
   }
 
   // An edge in the dependency graph.

--- a/buf/registry/legacy/federation/v1beta1/graph.proto
+++ b/buf/registry/legacy/federation/v1beta1/graph.proto
@@ -51,14 +51,14 @@ message Graph {
       (buf.validate.field).string.hostname = true
     ];
   }
-
   // An edge in the dependency graph.
   message Edge {
     // The Node of the start of the edge.
     Node from_node = 1 [(buf.validate.field).required = true];
-    // The Commit of the end of the edge.
+    // The Node of the end of the edge.
     Node to_node = 2 [(buf.validate.field).required = true];
   }
+
   // The nodes of the graph, each of which are Commits.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
   // The edges of the graph.

--- a/buf/registry/legacy/federation/v1beta1/graph_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/graph_service.proto
@@ -1,0 +1,77 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.legacy.federation.v1beta1;
+
+import "buf/registry/legacy/federation/v1beta1/graph.proto";
+import "buf/registry/legacy/federation/v1beta1/resource.proto";
+import "buf/registry/module/v1beta1/digest.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/legacy/federation/v1beta1";
+
+// Get dependency graphs.
+//
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
+service GraphService {
+  // Get a dependency graph that includes the given Commits.
+  //
+  // Commits will be resolved via the given ResourceRefs, and all Commits will be included in the
+  // graph, along with their dependencies.
+  //
+  // A dependency graph is a directed acyclic graph.
+  //
+  // See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+  // and not this package.
+  rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
+message GetGraphRequest {
+  // The references to resolve to Commits to include in the graph.
+  //
+  // See the documentation on ResourceRef for resource resolution details.
+  //
+  // Once the resource is resolved, the following Commit is included:
+  //   - If a Module is referenced, the Commit of the default Label is included.
+  //   - If a Label is referenced, the Commit of this Label is included.
+  //   - If a Commit is referenced, the Commit is included.
+  //
+  // The specified ResourceRefs must reference unique Modules, that is no two ResourceRefs
+  // may resolve to the same Module.
+  repeated ResourceRef resource_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+  // The DigestType to return for Commit nodes.
+  //
+  // If this DigestType is not available, an error is returned.
+  // Note that certain DigestTypes may be deprecated over time.
+  //
+  // If not set, the latest DigestType is used.
+  buf.registry.module.v1beta1.DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
+}
+
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
+message GetGraphResponse {
+  // The Graph calculated for the Commits.
+  Graph graph = 1 [(buf.validate.field).required = true];
+}

--- a/buf/registry/legacy/federation/v1beta1/resource.proto
+++ b/buf/registry/legacy/federation/v1beta1/resource.proto
@@ -1,0 +1,101 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.legacy.federation.v1beta1;
+
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/legacy/federation/v1beta1";
+
+// A reference to any of:
+//   - Module
+//   - Label
+//   - Commit
+//
+// The id or name is resolved to a specific resource.
+// If an id is passed, this is interpreted as being the id of the resource.
+// If a name is passed, the semantics according to ResourceRef.Name are applied.
+//
+// ResourceRefs can only be used in requests, and only for read-only RPCs, that is
+// you should not use an arbitrary reference when modifying a specific resource.
+//
+// ResourceRefs cannot reference archived Labels. The only way to retrieve an archived Label
+// is to use LabelService.GetLabels.
+//
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
+message ResourceRef {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+  option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;
+
+  // The fully-qualified name component of a ResourceRef.
+  //
+  // The following semantics are applied:
+  //   - If the child oneof is not specified, the name is interpreted to reference a Module.
+  //   - If label_name is specified, the name is interpreted to reference a Label.
+  //   - If ref is specified, it is interpreted to be either an id or name.
+  //     - If an id, this is equivalent to setting the id field on ResourceRef. However,
+  //       backends can choose to validate that the owner and module fields match the resource
+  //       referenced, as additional validation.
+  //     - If a name, this is interpreted to be a Label name or an ID of a Commit without any dashes.
+  //     - If there is a conflict between names across resources (for example, there is a Commit id
+  //       and Label name of the same value), the following order of precedence is applied:
+  //       - Commit
+  //       - Label
+  //
+  // Names can only be used in requests, and only for read-only RPCs, that is
+  // you should not use an arbitrary reference when modifying a specific resource.
+  message Name {
+    // The name of the User or Organization that owns the resource.
+    string owner = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 32
+    ];
+    // The name of the Module the contains or is the resource.
+    string module = 2 [(buf.validate.field).string = {
+      min_len: 2,
+      max_len: 100
+    }];
+    // If the oneof is present but empty, this should be treated as not present.
+    oneof child {
+      // The name of the Label.
+      //
+      // If this value is present but empty, this should be treated as not present, that is
+      // an empty value is the same as a null value.
+      string label_name = 3 [(buf.validate.field).string.max_len = 250];
+      // The untyped reference, applying the semantics as documented on the Name message.
+      //
+      // If this value is present but empty, this should be treated as not present, that is
+      // an empty value is the same as a null value.
+      string ref = 4;
+    }
+  }
+
+  oneof value {
+    option (buf.validate.oneof).required = true;
+    // The id of the resource.
+    string id = 1 [(buf.validate.field).string.uuid = true];
+    // The fully-qualified name of the resource.
+    Name name = 2;
+  }
+
+  // The registry hostname of the resource.
+  string registry = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.hostname = true
+  ];
+}

--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -1,0 +1,118 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.legacy.federation.v1beta1;
+
+import "buf/registry/module/v1beta1/commit.proto";
+import "buf/registry/module/v1beta1/file.proto";
+import "buf/registry/module/v1beta1/label.proto";
+import "buf/registry/module/v1beta1/module.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/legacy/federation/v1beta1";
+
+// Upload contents.
+//
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
+service UploadService {
+  // Upload contents for given set of Modules.
+  //
+  // Content consists of the Files: .proto files, license files, and documentation files.
+  //
+  // See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+  // and not this package.
+  rpc Upload(UploadRequest) returns (UploadResponse) {}
+}
+
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
+message UploadRequest {
+  // A dependency of Content, either referencing another Content message, or referencing
+  // a Commit that already exists.
+  message DepRef {
+    // The Module of the dep.
+    buf.registry.module.v1beta1.ModuleRef module_ref = 1 [(buf.validate.field).required = true];
+    // The commit_id of the Commit, if this is referencing a Commit that already exists.
+    //
+    // If the ModuleRef refers to a Module that has associated Content, this field should *not*
+    // be set, and setting it is an error.
+    string commit_id = 2 [(buf.validate.field).string.uuid = true];
+    // The registry hostname of the dep.
+    string registry = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.hostname = true
+    ];
+  }
+  // Content to upload for a given reference.
+  message Content {
+    // The Module of the reference.
+    buf.registry.module.v1beta1.ModuleRef module_ref = 1 [(buf.validate.field).required = true];
+    // The dependencies of the reference.
+    //
+    // This will include all transitive dependencies.
+    repeated DepRef dep_refs = 2;
+    // The Files of the Content.
+    //
+    // This will consist of the .proto files, license files, and documentation files.
+    repeated buf.registry.module.v1beta1.File files = 3 [(buf.validate.field).repeated.min_items = 1];
+    // The original v1beta1 or v1 buf.yaml file that encapsulated this reference, if it existed.
+    //
+    // This is used in deprecated digest calculations only. None of the structured
+    // information within this File will or should convey further information about the reference.
+    buf.registry.module.v1beta1.File v1_buf_yaml_file = 4;
+    // The original v1beta1 or v1 buf.lock file that encapsulated this reference, if it existed.
+    //
+    // This is used in deprecated digest calculations only. None of the structured
+    // information within this File will or should convey further information about the reference.
+    //
+    // Importantly, this file is *not* used to determine the dependencies of the reference. To
+    // specify the dependencies, use the dep_refs fields.
+    buf.registry.module.v1beta1.File v1_buf_lock_file = 5;
+    // The labels to associate with the Commit for the Content.
+    //
+    // If an id is set, this id must represent a Label that already exists and is
+    // owned by the Module. The Label will point to the newly-created Commits for the References,
+    // or will be updated to point to the pre-existing Commit for the Reference.
+    //
+    // If no labels are referenced, the default Label for the Module is used.
+    //
+    // If the Labels do not exist, they will be created.
+    // If the Labels were archived, they will be unarchived.
+    repeated buf.registry.module.v1beta1.ScopedLabelRef scoped_label_refs = 6;
+    // The URL of the source control commit to associate with the Commit for this Content.
+    //
+    // BSR users can navigate to this link to find source control information that is relevant to this Commit
+    // (e.g. commit description, PR discussion, authors, approvers, etc.).
+    string source_control_url = 7 [
+      (buf.validate.field).string.uri = true,
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore_empty = true
+    ];
+  }
+  // The Contents of all references.
+  repeated Content contents = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+// See the package documentation for more details. You should likely use buf.registry.module.v1beta1
+// and not this package.
+message UploadResponse {
+  // The Commits for each reference in the same order as given on the request.
+  //
+  // A single Commit will be returned for each reference. These Commits may or may not be new.
+  // If nothing changed for a given reference, the existing Commit will be returned.
+  repeated buf.registry.module.v1beta1.Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
+}

--- a/buf/registry/module/v1beta1/graph.proto
+++ b/buf/registry/module/v1beta1/graph.proto
@@ -34,14 +34,14 @@ message Graph {
       (buf.validate.field).string.uuid = true
     ];
   }
-
   // An edge in the dependency graph.
   message Edge {
     // The Node of the start of the edge.
     Node from_node = 1 [(buf.validate.field).required = true];
-    // The Commit of the end of the edge.
+    // The Node of the end of the edge.
     Node to_node = 2 [(buf.validate.field).required = true];
   }
+
   // The nodes of the graph, each of which are Commits.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
   // The edges of the graph.


### PR DESCRIPTION
This adds the `buf.registry.legacy.federation.v1beta1` package.

We need to support legacy federation for a few of our early customers, and this is the easiest way for us to do so. It effectively means supporting federation on two endpoints: `GetGraph` and `Upload`. The edits to these endpoints and their associated types will mean an API that is sufficiently different and unclean that we instead are splitting these out into their own package (and associated endpoints).