### PR TITLE
Make registry field more lenient

### DIFF
--- a/buf/registry/legacy/federation/v1beta1/graph.proto
+++ b/buf/registry/legacy/federation/v1beta1/graph.proto
@@ -37,7 +37,7 @@ message Graph {
     buf.registry.module.v1beta1.Commit commit = 1 [(buf.validate.field).required = true];
     // The registry hostname of the Commit.
     string registry = 2 [
-      (buf.validate.field).required = true,
+      (buf.validate.field).required = true
     ];
   }
   // A node in the dependency graph.
@@ -46,7 +46,7 @@ message Graph {
     string commit_id = 1 [(buf.validate.field).required = true];
     // The registry hostname of the Node.
     string registry = 2 [
-      (buf.validate.field).required = true,
+      (buf.validate.field).required = true
     ];
   }
   // An edge in the dependency graph.

--- a/buf/registry/legacy/federation/v1beta1/graph.proto
+++ b/buf/registry/legacy/federation/v1beta1/graph.proto
@@ -38,7 +38,6 @@ message Graph {
     // The registry hostname of the Commit.
     string registry = 2 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.hostname = true
     ];
   }
   // A node in the dependency graph.
@@ -48,7 +47,6 @@ message Graph {
     // The registry hostname of the Node.
     string registry = 2 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.hostname = true
     ];
   }
   // An edge in the dependency graph.

--- a/buf/registry/legacy/federation/v1beta1/graph.proto
+++ b/buf/registry/legacy/federation/v1beta1/graph.proto
@@ -36,18 +36,14 @@ message Graph {
     // The top-level Commit.
     buf.registry.module.v1beta1.Commit commit = 1 [(buf.validate.field).required = true];
     // The registry hostname of the Commit.
-    string registry = 2 [
-      (buf.validate.field).required = true
-    ];
+    string registry = 2 [(buf.validate.field).required = true];
   }
   // A node in the dependency graph.
   message Node {
     // The commit of the node.
     string commit_id = 1 [(buf.validate.field).required = true];
     // The registry hostname of the Node.
-    string registry = 2 [
-      (buf.validate.field).required = true
-    ];
+    string registry = 2 [(buf.validate.field).required = true];
   }
   // An edge in the dependency graph.
   message Edge {

--- a/buf/registry/legacy/federation/v1beta1/resource.proto
+++ b/buf/registry/legacy/federation/v1beta1/resource.proto
@@ -96,6 +96,5 @@ message ResourceRef {
   // The registry hostname of the resource.
   string registry = 3 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.hostname = true
   ];
 }

--- a/buf/registry/legacy/federation/v1beta1/resource.proto
+++ b/buf/registry/legacy/federation/v1beta1/resource.proto
@@ -94,7 +94,5 @@ message ResourceRef {
   }
 
   // The registry hostname of the resource.
-  string registry = 3 [
-    (buf.validate.field).required = true
-  ];
+  string registry = 3 [(buf.validate.field).required = true];
 }

--- a/buf/registry/legacy/federation/v1beta1/resource.proto
+++ b/buf/registry/legacy/federation/v1beta1/resource.proto
@@ -95,6 +95,6 @@ message ResourceRef {
 
   // The registry hostname of the resource.
   string registry = 3 [
-    (buf.validate.field).required = true,
+    (buf.validate.field).required = true
   ];
 }

--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -53,7 +53,7 @@ message UploadRequest {
     string commit_id = 2 [(buf.validate.field).string.uuid = true];
     // The registry hostname of the dep.
     string registry = 3 [
-      (buf.validate.field).required = true,
+      (buf.validate.field).required = true
     ];
   }
   // Content to upload for a given reference.

--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -54,7 +54,6 @@ message UploadRequest {
     // The registry hostname of the dep.
     string registry = 3 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.hostname = true
     ];
   }
   // Content to upload for a given reference.

--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -52,9 +52,7 @@ message UploadRequest {
     // be set, and setting it is an error.
     string commit_id = 2 [(buf.validate.field).string.uuid = true];
     // The registry hostname of the dep.
-    string registry = 3 [
-      (buf.validate.field).required = true
-    ];
+    string registry = 3 [(buf.validate.field).required = true];
   }
   // Content to upload for a given reference.
   message Content {


### PR DESCRIPTION
Protovalidate doesn't yet have a rule that covers what we need for the registry field. We internally rely on the field being allowed to contain an address with a port, not just a hostname; while protovalidate does have an address validator that allows either an IP or a hostname, it lacks an address with optional port validator. Rather than try to write a complicated regular expression, I think it's best to just allow the field to contain any string, which will eventually be validated implicitly by trying to use it as an address anyways.