### PR TITLE
Add UUID validation to legacy graph service commit_id

### DIFF
--- a/buf/registry/legacy/federation/v1beta1/graph.proto
+++ b/buf/registry/legacy/federation/v1beta1/graph.proto
@@ -41,7 +41,10 @@ message Graph {
   // A node in the dependency graph.
   message Node {
     // The commit of the node.
-    string commit_id = 1 [(buf.validate.field).required = true];
+    string commit_id = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.uuid = true
+    ];
     // The registry hostname of the Node.
     string registry = 2 [(buf.validate.field).required = true];
   }


### PR DESCRIPTION
Add UUID field validation for type `buf.registry.legacy.federation.v1beta1.Graph.Node` field `commit_id`.