### PR TITLE
Relax the requirement on v1 buf.yaml being present

### DIFF
--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -66,19 +66,6 @@ message UploadRequest {
     //
     // This will consist of the .proto files, license files, and documentation files.
     repeated buf.registry.module.v1beta1.File files = 3 [(buf.validate.field).repeated.min_items = 1];
-    // The original v1beta1 or v1 buf.yaml file that encapsulated this reference, if it existed.
-    //
-    // This is used in deprecated digest calculations only. None of the structured
-    // information within this File will or should convey further information about the reference.
-    buf.registry.module.v1beta1.File v1_buf_yaml_file = 4;
-    // The original v1beta1 or v1 buf.lock file that encapsulated this reference, if it existed.
-    //
-    // This is used in deprecated digest calculations only. None of the structured
-    // information within this File will or should convey further information about the reference.
-    //
-    // Importantly, this file is *not* used to determine the dependencies of the reference. To
-    // specify the dependencies, use the dep_refs fields.
-    buf.registry.module.v1beta1.File v1_buf_lock_file = 5;
     // The labels to associate with the Commit for the Content.
     //
     // If an id is set, this id must represent a Label that already exists and is
@@ -89,12 +76,12 @@ message UploadRequest {
     //
     // If the Labels do not exist, they will be created.
     // If the Labels were archived, they will be unarchived.
-    repeated buf.registry.module.v1beta1.ScopedLabelRef scoped_label_refs = 6;
+    repeated buf.registry.module.v1beta1.ScopedLabelRef scoped_label_refs = 4;
     // The URL of the source control commit to associate with the Commit for this Content.
     //
     // BSR users can navigate to this link to find source control information that is relevant to this Commit
     // (e.g. commit description, PR discussion, authors, approvers, etc.).
-    string source_control_url = 7 [
+    string source_control_url = 5 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
       (buf.validate.field).ignore_empty = true

--- a/buf/registry/module/v1beta1/download_service.proto
+++ b/buf/registry/module/v1beta1/download_service.proto
@@ -112,13 +112,13 @@ message DownloadResponse {
     //
     // If no paths match and paths_allow_not_exist is set, this may be empty.
     repeated File files = 2;
-    // The original v1beta1 or v1 buf.yaml file that encapsulated this reference.
+    // The original v1beta1 or v1 buf.yaml file that encapsulated this reference, if it existed.
     //
     // If the reference was encapsulated by a v2 buf.yaml, this will be a synthesized v1 buf.yaml.
     //
     // This is used in deprecated digest calculations only. None of the structured
     // information within this File conveys further information about the reference.
-    File v1_buf_yaml_file = 3 [(buf.validate.field).required = true];
+    File v1_buf_yaml_file = 3;
     // The original buf.lock file that encapsulated this reference, if it existed.
     //
     // If the reference was encapsulated by a v2 buf.lock with dependencies, this will be a

--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -56,19 +56,6 @@ message UploadRequest {
     //
     // This will consist of the .proto files, license files, and documentation files.
     repeated File files = 3 [(buf.validate.field).repeated.min_items = 1];
-    // The original v1beta1 or v1 buf.yaml file that encapsulated this reference, if it existed.
-    //
-    // This is used in deprecated digest calculations only. None of the structured
-    // information within this File will or should convey further information about the reference.
-    File v1_buf_yaml_file = 4;
-    // The original v1beta1 or v1 buf.lock file that encapsulated this reference, if it existed.
-    //
-    // This is used in deprecated digest calculations only. None of the structured
-    // information within this File will or should convey further information about the reference.
-    //
-    // Importantly, this file is *not* used to determine the dependencies of the reference. To
-    // specify the dependencies, use the dep_refs fields.
-    File v1_buf_lock_file = 5;
     // The labels to associate with the Commit for the Content.
     //
     // If an id is set, this id must represent a Label that already exists and is
@@ -79,12 +66,12 @@ message UploadRequest {
     //
     // If the Labels do not exist, they will be created.
     // If the Labels were archived, they will be unarchived.
-    repeated ScopedLabelRef scoped_label_refs = 6;
+    repeated ScopedLabelRef scoped_label_refs = 4;
     // The URL of the source control commit to associate with the Commit for this Content.
     //
     // BSR users can navigate to this link to find source control information that is relevant to this Commit
     // (e.g. commit description, PR discussion, authors, approvers, etc.).
-    string source_control_url = 7 [
+    string source_control_url = 5 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
       (buf.validate.field).ignore_empty = true


### PR DESCRIPTION
This file is not required to be present on download. If returned, it will be used in digest calculations only.

Update the UploadRequeset to stop sending v1 buf.yaml/buf.lock files. They will be synthesized in all cases on the BSR to support older digest types.