### PR TITLE
Make `dep_refs.commit_id` optional

### DIFF
--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -42,7 +42,7 @@ message UploadRequest {
     //
     // If the ModuleRef refers to a Module that has associated Content, this field should *not*
     // be set, and setting it is an error.
-    string commit_id = 2 [(buf.validate.field).string.uuid = true];
+    optional string commit_id = 2 [(buf.validate.field).string.uuid = true];
   }
   // Content to upload for a given reference.
   message Content {


### PR DESCRIPTION
This is only populated if the dependency commit already exists, but for codependent modules being pushed, `commit_id` should not be set.