### PR TITLE
Move DepRefs and DigestType to top-level

### DIFF
--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -104,6 +104,9 @@ message UploadRequest {
   //
   // Dependencies between Contents are implicit and do not need to be specified. The BSR will detect
   // dependencies between Contents via .proto imports.
+  //
+  // Commits should be unique by Module, that is no two dep_refs should have the same Module but
+  // different Commit IDs.
   repeated DepRef dep_refs = 2;
 }
 

--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -44,7 +44,7 @@ message UploadRequest {
   // A dependency of one or more references specified by Contents.
   //
   // Dependencies between Contents are implicit and do not need to be specified. The BSR will detect
-  // dependencies between Contenta via .proto imports.
+  // dependencies between Contents via .proto imports.
   message DepRef {
     // The commit_id of the dependency.
     string commit_id = 1 [

--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -41,36 +41,32 @@ service UploadService {
 // See the package documentation for more details. You should likely use buf.registry.module.v1beta1
 // and not this package.
 message UploadRequest {
-  // A dependency of Content, either referencing another Content message, or referencing
-  // a Commit that already exists.
+  // A dependency of one or more references specified by Contents.
+  //
+  // Dependencies between Contents are implicit and do not need to be specified. The BSR will detect
+  // dependencies between Contenta via .proto imports.
   message DepRef {
-    // The Module of the dep.
-    buf.registry.module.v1beta1.ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-    // The commit_id of the Commit, if this is referencing a Commit that already exists.
-    //
-    // If the ModuleRef refers to a Module that has associated Content, this field should *not*
-    // be set, and setting it is an error.
-    string commit_id = 2 [(buf.validate.field).string.uuid = true];
-    // The registry hostname of the dep.
-    string registry = 3 [(buf.validate.field).required = true];
+    // The commit_id of the dependency.
+    string commit_id = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.uuid = true
+    ];
+    // The registry hostname of the dependency.
+    string registry = 2 [(buf.validate.field).required = true];
   }
   // Content to upload for a given reference.
   message Content {
     // The Module of the reference.
     buf.registry.module.v1beta1.ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-    // The dependencies of the reference.
-    //
-    // This will include all transitive dependencies.
-    repeated DepRef dep_refs = 2;
     // The Files of the Content.
     //
     // This will consist of the .proto files, license files, and documentation files.
-    repeated buf.registry.module.v1beta1.File files = 3 [(buf.validate.field).repeated.min_items = 1];
+    repeated buf.registry.module.v1beta1.File files = 2 [(buf.validate.field).repeated.min_items = 1];
     // The original v1beta1 or v1 buf.yaml file that encapsulated this reference, if it existed.
     //
     // This is used in deprecated digest calculations only. None of the structured
     // information within this File will or should convey further information about the reference.
-    buf.registry.module.v1beta1.File v1_buf_yaml_file = 4;
+    buf.registry.module.v1beta1.File v1_buf_yaml_file = 3;
     // The original v1beta1 or v1 buf.lock file that encapsulated this reference, if it existed.
     //
     // This is used in deprecated digest calculations only. None of the structured
@@ -78,7 +74,7 @@ message UploadRequest {
     //
     // Importantly, this file is *not* used to determine the dependencies of the reference. To
     // specify the dependencies, use the dep_refs fields.
-    buf.registry.module.v1beta1.File v1_buf_lock_file = 5;
+    buf.registry.module.v1beta1.File v1_buf_lock_file = 4;
     // The labels to associate with the Commit for the Content.
     //
     // If an id is set, this id must represent a Label that already exists and is
@@ -89,12 +85,12 @@ message UploadRequest {
     //
     // If the Labels do not exist, they will be created.
     // If the Labels were archived, they will be unarchived.
-    repeated buf.registry.module.v1beta1.ScopedLabelRef scoped_label_refs = 6;
+    repeated buf.registry.module.v1beta1.ScopedLabelRef scoped_label_refs = 5;
     // The URL of the source control commit to associate with the Commit for this Content.
     //
     // BSR users can navigate to this link to find source control information that is relevant to this Commit
     // (e.g. commit description, PR discussion, authors, approvers, etc.).
-    string source_control_url = 7 [
+    string source_control_url = 6 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
       (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
@@ -102,6 +98,13 @@ message UploadRequest {
   }
   // The Contents of all references.
   repeated Content contents = 1 [(buf.validate.field).repeated.min_items = 1];
+  // The dependencies of the references specified by Contents.
+  //
+  // This will include all transitive dependencies.
+  //
+  // Dependencies between Contents are implicit and do not need to be specified. The BSR will detect
+  // dependencies between Contents via .proto imports.
+  repeated DepRef dep_refs = 2;
 }
 
 // See the package documentation for more details. You should likely use buf.registry.module.v1beta1

--- a/buf/registry/module/v1beta1/download_service.proto
+++ b/buf/registry/module/v1beta1/download_service.proto
@@ -82,19 +82,19 @@ message DownloadRequest {
     //
     // If false, it is an error to specify non-existent file paths.
     bool paths_allow_not_exist = 4;
-    // The DigestType to return for the Commit of this reference.
-    //
-    // If this DigestType is not available, an error is returned.
-    // Note that certain DigestTypes may be deprecated over time.
-    //
-    // If not set, the latest DigestType is used, currently B5.
-    DigestType digest_type = 5 [(buf.validate.field).enum.defined_only = true];
   }
   // The references to get contents for.
   repeated Value values = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
   ];
+  // The DigestType to return for the Commits of the references.
+  //
+  // If this DigestType is not available, an error is returned.
+  // Note that certain DigestTypes may be deprecated over time.
+  //
+  // If not set, the latest DigestType is used, currently B5.
+  DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
 message DownloadResponse {

--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -33,37 +33,19 @@ service UploadService {
 }
 
 message UploadRequest {
-  // A dependency of Content, either referencing another Content message, or referencing
-  // a Commit that already exists.
-  message DepRef {
-    // The Module of the dep.
-    ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-    // The commit_id of the Commit, if this is referencing a Commit that already exists.
-    //
-    // If the ModuleRef refers to a Module that has associated Content, this field should be empty,
-    // and setting a value is an error.
-    string commit_id = 2 [
-      (buf.validate.field).string.uuid = true,
-      (buf.validate.field).ignore_empty = true
-    ];
-  }
   // Content to upload for a given reference.
   message Content {
     // The Module of the reference.
     ModuleRef module_ref = 1 [(buf.validate.field).required = true];
-    // The dependencies of the reference.
-    //
-    // This will include all transitive dependencies.
-    repeated DepRef dep_refs = 2;
     // The Files of the Content.
     //
     // This will consist of the .proto files, license files, and documentation files.
-    repeated File files = 3 [(buf.validate.field).repeated.min_items = 1];
+    repeated File files = 2 [(buf.validate.field).repeated.min_items = 1];
     // The original v1beta1 or v1 buf.yaml file that encapsulated this reference, if it existed.
     //
     // This is used in deprecated digest calculations only. None of the structured
     // information within this File will or should convey further information about the reference.
-    File v1_buf_yaml_file = 4;
+    File v1_buf_yaml_file = 3;
     // The original v1beta1 or v1 buf.lock file that encapsulated this reference, if it existed.
     //
     // This is used in deprecated digest calculations only. None of the structured
@@ -71,7 +53,7 @@ message UploadRequest {
     //
     // Importantly, this file is *not* used to determine the dependencies of the reference. To
     // specify the dependencies, use the dep_refs fields.
-    File v1_buf_lock_file = 5;
+    File v1_buf_lock_file = 4;
     // The labels to associate with the Commit for the Content.
     //
     // If an id is set, this id must represent a Label that already exists and is
@@ -82,12 +64,12 @@ message UploadRequest {
     //
     // If the Labels do not exist, they will be created.
     // If the Labels were archived, they will be unarchived.
-    repeated ScopedLabelRef scoped_label_refs = 6;
+    repeated ScopedLabelRef scoped_label_refs = 5;
     // The URL of the source control commit to associate with the Commit for this Content.
     //
     // BSR users can navigate to this link to find source control information that is relevant to this Commit
     // (e.g. commit description, PR discussion, authors, approvers, etc.).
-    string source_control_url = 7 [
+    string source_control_url = 6 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
       (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
@@ -95,6 +77,13 @@ message UploadRequest {
   }
   // The Contents of all references.
   repeated Content contents = 1 [(buf.validate.field).repeated.min_items = 1];
+  // The dependencies of the references specified by Contents.
+  //
+  // Dependencies between Contents are implicit and do not need to be specified. The BSR will detect
+  // dependencies between Contenta via .proto imports.
+  //
+  // This will include all transitive dependencies.
+  repeated string dep_commit_ids = 2 [(buf.validate.field).repeated.items.string.uuid = true];
 }
 
 message UploadResponse {

--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -83,6 +83,9 @@ message UploadRequest {
   // dependencies between Contenta via .proto imports.
   //
   // This will include all transitive dependencies.
+  //
+  // Commits should be unique by Module, that is no two dep_commit_ids should have the same Module but
+  // different Commit IDs.
   repeated string dep_commit_ids = 2 [(buf.validate.field).repeated.items.string.uuid = true];
 }
 


### PR DESCRIPTION
This PR's primary purpose is to remove the need to specify dependencies between Contents on Upload, and to move external dependencies to the top-level of the UploadRequest. We do not need to manually specify dependencies between Contents, as this is implicitly done via .proto imports. We also want to make sure that for a given set of Contents, there is exactly one dependency Commit ID for a given Module. This matches what we have in Workspaces. The API will no longer enable uploading multiple Workspaces in one RPC, but we see no use case for this.

This PR also moves DigestType to the top-level of DownloadRequest, to match the other RPCs.