### PR TITLE
Use `ignore_empty`

### DIFF
--- a/buf/registry/legacy/federation/v1beta1/upload_service.proto
+++ b/buf/registry/legacy/federation/v1beta1/upload_service.proto
@@ -93,7 +93,7 @@ message UploadRequest {
     string source_control_url = 6 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+      (buf.validate.field).ignore_empty = true
     ];
   }
   // The Contents of all references.

--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -70,6 +70,6 @@ message Commit {
   string source_control_url = 7 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 255,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore_empty = true
   ];
 }

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -63,7 +63,7 @@ message Module {
   string url = 9 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 255,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore_empty = true
   ];
   // The name of the default Label of the Module.
   //

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -130,7 +130,7 @@ message CreateModulesRequest {
     string url = 5 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+      (buf.validate.field).ignore_empty = true
     ];
     // The name of the default Label of the Module.
     //

--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -72,7 +72,7 @@ message UploadRequest {
     string source_control_url = 6 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+      (buf.validate.field).ignore_empty = true
     ];
   }
   // The Contents of all references.

--- a/buf/registry/owner/v1beta1/organization.proto
+++ b/buf/registry/owner/v1beta1/organization.proto
@@ -52,7 +52,7 @@ message Organization {
   string url = 6 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 255,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore_empty = true
   ];
   // The verification status of the Organization.
   OrganizationVerificationStatus verification_status = 7 [

--- a/buf/registry/owner/v1beta1/organization_service.proto
+++ b/buf/registry/owner/v1beta1/organization_service.proto
@@ -122,7 +122,7 @@ message CreateOrganizationsRequest {
     string url = 3 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+      (buf.validate.field).ignore_empty = true
     ];
     // The verification status of the Organization.
     //

--- a/buf/registry/owner/v1beta1/user.proto
+++ b/buf/registry/owner/v1beta1/user.proto
@@ -62,7 +62,7 @@ message User {
   string url = 8 [
     (buf.validate.field).string.uri = true,
     (buf.validate.field).string.max_len = 255,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore_empty = true
   ];
   // The verification status of the User.
   UserVerificationStatus verification_status = 9 [

--- a/buf/registry/owner/v1beta1/user_service.proto
+++ b/buf/registry/owner/v1beta1/user_service.proto
@@ -139,7 +139,7 @@ message CreateUsersRequest {
     string url = 4 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+      (buf.validate.field).ignore_empty = true
     ];
     // The verification status of the User.
     //


### PR DESCRIPTION
Temporarily use deprecated rule `ignore_empty` while protovalidate-go supports the new ignore enum, to get some backend work unblocked.