### PR TITLE
Add start_commit_id to ListLabelHistoryRequest

### DIFF
--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -143,6 +143,11 @@ message ListLabelHistoryRequest {
   uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
   // The page to start from.
   //
+  // The value may be a page_token returned from ListLabelHistoryResponse,
+  // or it may be a Commit id.
+  //
+  // If a Commit id, the returned history will start at that Commit.
+  //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The Label to list history for.

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -147,6 +147,7 @@ message ListLabelHistoryRequest {
   // or it may be a Commit id.
   //
   // If a Commit id, the returned history will start at that Commit.
+  // It is an error to provide a Commit id that doesn't exist on the Label.
   //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -143,12 +143,6 @@ message ListLabelHistoryRequest {
   uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
   // The page to start from.
   //
-  // The value may be a page_token returned from ListLabelHistoryResponse,
-  // or it may be a Commit id.
-  //
-  // If a Commit id, the returned history will start at that Commit.
-  // It is an error to provide a Commit id that doesn't exist on the Label.
-  //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The Label to list history for.
@@ -166,6 +160,10 @@ message ListLabelHistoryRequest {
   //
   // If not set, Commits with any CommitCheckStatus value are returned.
   repeated CommitCheckStatus commit_check_statuses = 6 [(buf.validate.field).repeated.items.enum.defined_only = true];
+  // The Commit id to start from.
+  //
+  // It is an error to provide a Commit id that doesn't exist on the Label.
+  string start_commit_id = 7 [(buf.validate.field).string.uuid = true];
 }
 
 message ListLabelHistoryResponse {

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -144,6 +144,11 @@ message ListLabelHistoryRequest {
   uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
   // The page to start from.
   //
+  // The value may be a page_token returned from ListLabelHistoryResponse,
+  // or it may be a Commit id.
+  //
+  // If a Commit id, the returned history will start at that Commit.
+  //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The Label to list history for.

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -148,6 +148,7 @@ message ListLabelHistoryRequest {
   // or it may be a Commit id.
   //
   // If a Commit id, the returned history will start at that Commit.
+  // It is an error to provide a Commit id that doesn't exist on the Label.
   //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -144,12 +144,6 @@ message ListLabelHistoryRequest {
   uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
   // The page to start from.
   //
-  // The value may be a page_token returned from ListLabelHistoryResponse,
-  // or it may be a Commit id.
-  //
-  // If a Commit id, the returned history will start at that Commit.
-  // It is an error to provide a Commit id that doesn't exist on the Label.
-  //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The Label to list history for.
@@ -174,6 +168,10 @@ message ListLabelHistoryRequest {
   //
   // If not set, Commits with any CommitCheckStatus value are returned.
   repeated CommitCheckStatus commit_check_statuses = 6 [(buf.validate.field).repeated.items.enum.defined_only = true];
+  // The Commit id to start from.
+  //
+  // It is an error to provide a Commit id that doesn't exist on the Label.
+  string start_commit_id = 7 [(buf.validate.field).string.uuid = true];
 }
 
 message ListLabelHistoryResponse {


### PR DESCRIPTION
To view a diff for a commit on a label we need to be able to get the previous commit on that label. Added `start_commit_id` so we can fetch the history starting at the desired commit and using a page size of 2 can also get the previous commit.