### PR TITLE
Fix field numbers for v1 ListLabelHistoryRequest

### DIFF
--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -159,11 +159,11 @@ message ListLabelHistoryRequest {
   // Only return Commits that have one of these CommitCheckStatus values for this label.
   //
   // If not set, Commits with any CommitCheckStatus value are returned.
-  repeated CommitCheckStatus commit_check_statuses = 6 [(buf.validate.field).repeated.items.enum.defined_only = true];
+  repeated CommitCheckStatus commit_check_statuses = 5 [(buf.validate.field).repeated.items.enum.defined_only = true];
   // The Commit id to start from.
   //
   // It is an error to provide a Commit id that doesn't exist on the Label.
-  string start_commit_id = 7 [
+  string start_commit_id = 6 [
     (buf.validate.field).string.uuid = true,
     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
   ];


### PR DESCRIPTION
Field number 5 was inadvertently skipped in https://github.com/bufbuild/registry-proto/pull/80