### PR TITLE
Add ListCommits

### DIFF
--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -28,6 +28,10 @@ service CommitService {
   rpc GetCommits(GetCommitsRequest) returns (GetCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // List Commits for a given Module, Label, or Commit.
+  rpc ListCommits(ListCommitsRequest) returns (ListCommitsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }
 
 message GetCommitsRequest {
@@ -48,4 +52,52 @@ message GetCommitsRequest {
 message GetCommitsResponse {
   // The found Commits in the same order as requested.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message ListCommitsRequest {
+  // The list order.
+  enum Order {
+    ORDER_UNSPECIFIED = 0;
+    // Order by create_time oldest to newest.
+    ORDER_CREATE_TIME_ASC = 1;
+    // Order by create_time newest to oldest.
+    ORDER_CREATE_TIME_DESC = 2;
+  }
+  // The maximum number of items to return.
+  //
+  // The default value is 10.
+  uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
+  // The page to start from.
+  //
+  // If empty, the first page is returned,
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
+  // The reference to list Commits for.
+  //
+  // See the documentation on Ref for resource resolution details.
+  //
+  // Once the resource is resolved, the following Commits are listed:
+  //   - If a Module is referenced, all Commits for the Module are returned.
+  //   - If a Label is referenced, the Commit the Label points to is returned.
+  //     Use ListLabelHistory to get the history of Commits for a Label.
+  //   - If a Commit is referenced, this Commit is returned.
+  ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
+  // The order to return the Commits.
+  //
+  // If not specified, defaults to ORDER_CREATE_TIME_ASC.
+  //
+  // TODO: Do we want ORDER_CREATE_TIME_ASC to be the default?
+  // TODO: We are purposefully not making the default the zero enum value, however
+  // we may want to consider this.
+  Order order = 4 [(buf.validate.field).enum.defined_only = true];
+  // Only return Commits with an id that contains this string.
+  string id_query = 5 [(buf.validate.field).string.max_len = 32];
+}
+
+message ListCommitsResponse {
+  // The next page token.
+  //
+  // If empty, there are no more pages.
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
+  // The listed Commits.
+  repeated Commit commits = 2;
 }

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -29,6 +29,10 @@ service CommitService {
   rpc GetCommits(GetCommitsRequest) returns (GetCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // List Commits for a given Module, Label, or Commit.
+  rpc ListCommits(ListCommitsRequest) returns (ListCommitsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }
 
 message GetCommitsRequest {
@@ -56,4 +60,52 @@ message GetCommitsRequest {
 message GetCommitsResponse {
   // The found Commits in the same order as requested.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message ListCommitsRequest {
+  // The list order.
+  enum Order {
+    ORDER_UNSPECIFIED = 0;
+    // Order by create_time oldest to newest.
+    ORDER_CREATE_TIME_ASC = 1;
+    // Order by create_time newest to oldest.
+    ORDER_CREATE_TIME_DESC = 2;
+  }
+  // The maximum number of items to return.
+  //
+  // The default value is 10.
+  uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
+  // The page to start from.
+  //
+  // If empty, the first page is returned,
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
+  // The reference to list Commits for.
+  //
+  // See the documentation on Ref for resource resolution details.
+  //
+  // Once the resource is resolved, the following Commits are listed:
+  //   - If a Module is referenced, all Commits for the Module are returned.
+  //   - If a Label is referenced, the Commit the Label points to is returned.
+  //     Use ListLabelHistory to get the history of Commits for a Label.
+  //   - If a Commit is referenced, this Commit is returned.
+  ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
+  // The order to return the Commits.
+  //
+  // If not specified, defaults to ORDER_CREATE_TIME_ASC.
+  //
+  // TODO: Do we want ORDER_CREATE_TIME_ASC to be the default?
+  // TODO: We are purposefully not making the default the zero enum value, however
+  // we may want to consider this.
+  Order order = 4 [(buf.validate.field).enum.defined_only = true];
+  // Only return Commits with an id that contains this string.
+  string id_query = 5 [(buf.validate.field).string.max_len = 32];
+}
+
+message ListCommitsResponse {
+  // The next page token.
+  //
+  // If empty, there are no more pages.
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
+  // The listed Commits.
+  repeated Commit commits = 2;
 }


### PR DESCRIPTION
ListCommits copies the structure from ListLabels and adds an `id_query` field similar to the `name_query` on ListLabels.

This makes it possible for a user to use a short commit hash to find the one (or multiple) actual commits that match (for typeahead search in the label selector dropdown).