### PR TITLE
Document that query parameters are case-insensitive

### DIFF
--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -89,7 +89,7 @@ message ListCommitsRequest {
   // TODO: We are purposefully not making the default the zero enum value, however
   // we may want to consider this.
   Order order = 4 [(buf.validate.field).enum.defined_only = true];
-  // Only return Commits with an id that contains this string.
+  // Only return Commits with an id that contains this string using a case-insensitive comparison.
   string id_query = 5 [(buf.validate.field).string.max_len = 32];
 }
 

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -115,7 +115,7 @@ message ListLabelsRequest {
   //
   // TODO: Add custom CEL validation to validate the status field is one of DISABLED, PASSED, APPROVED.
   repeated CommitCheckStatus commit_check_statuses = 5 [(buf.validate.field).repeated.items.enum.defined_only = true];
-  // Only return Labels with a name that contains this string.
+  // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
 }
 

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -104,7 +104,7 @@ message ListCommitsRequest {
   //
   // If not set, the latest DigestType is used, currently B5.
   DigestType digest_type = 5 [(buf.validate.field).enum.defined_only = true];
-  // Only return Commits with an id that contains this string.
+  // Only return Commits with an id that contains this string using a case-insensitive comparison.
   string id_query = 6 [(buf.validate.field).string.max_len = 32];
 }
 

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -116,7 +116,7 @@ message ListLabelsRequest {
   //
   // TODO: Add custom CEL validation to validate the status field is one of DISABLED, PASSED, APPROVED.
   repeated CommitCheckStatus commit_check_statuses = 5 [(buf.validate.field).repeated.items.enum.defined_only = true];
-  // Only return Labels with a name that contains this string.
+  // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
 }
 


### PR DESCRIPTION
This is more useful today. Any client that cares about case sensitivity can post-process the returned results.