### PR TITLE
Change how archived labels work

### DIFF
--- a/buf/registry/module/v1/label.proto
+++ b/buf/registry/module/v1/label.proto
@@ -40,7 +40,7 @@ message Label {
   // The time the Label was archived if it is currently archived.
   //
   // If this field is not set, the Label is not currently archived.
-  google.protobuf.Timestamp archived_time = 4;
+  google.protobuf.Timestamp archive_time = 4;
   // The name of the Label.
   //
   // Unique within a given Module.

--- a/buf/registry/module/v1/label.proto
+++ b/buf/registry/module/v1/label.proto
@@ -37,8 +37,10 @@ message Label {
   google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
   // The last time the Label was updated on the BSR.
   google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
-  // Whether or not the Label is archived.
-  bool archived = 4;
+  // The time the Label was archived if it is currently archived.
+  //
+  // If this field is not set, the Label is not currently archived.
+  google.protobuf.Timestamp archived_time = 4;
   // The name of the Label.
   //
   // Unique within a given Module.

--- a/buf/registry/module/v1/label.proto
+++ b/buf/registry/module/v1/label.proto
@@ -37,10 +37,7 @@ message Label {
   google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
   // The last time the Label was updated on the BSR.
   google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
-  // Whether or not the Label was archived.
-  //
-  // If a Label is archived, the API considers it to not exist and will not return archived
-  // Labels, except when calling LabelService.GetLabels.
+  // Whether or not the Label is archived.
   bool archived = 4;
   // The name of the Label.
   //

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -54,6 +54,12 @@ service LabelService {
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
+  // Unarchive existing Labels.
+  //
+  // This operation is atomic. Either all Labels are unarchived or an error is returned.
+  rpc UnarchiveLabels(UnarchiveLabelsRequest) returns (UnarchiveLabelsResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
 }
 
 message GetLabelsRequest {
@@ -226,3 +232,13 @@ message ArchiveLabelsRequest {
 }
 
 message ArchiveLabelsResponse {}
+
+message UnarchiveLabelsRequest {
+  // The Labels to unarchive.
+  repeated LabelRef label_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message UnarchiveLabelsResponse {}

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -134,6 +134,8 @@ message ListLabelsRequest {
   // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
   // The archived filter on the returned Labels.
+  //
+  // If not specified, defaults to ARCHIVE_FILTER_ONLY_UNARCHIVED.
   ArchivedFilter archived_filter = 7 [(buf.validate.field).enum.defined_only = true];
 }
 

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -87,14 +87,14 @@ message ListLabelsRequest {
     ORDER_CREATE_TIME_ASC = 2;
   }
   // The filter on the archived field of a Label.
-  enum ArchivedFilter {
-    ARCHIVED_FILTER_UNSPECIFIED = 0;
+  enum ArchiveFilter {
+    ARCHIVE_FILTER_UNSPECIFIED = 0;
     // Return only unarchived labels.
-    ARCHIVED_FILTER_ONLY_UNARCHIVED = 1;
+    ARCHIVE_FILTER_UNARCHIVED_ONLY = 1;
     // Return only archived labels.
-    ARCHIVED_FILTER_ONLY_ARCHIVED = 2;
+    ARCHIVE_FILTER_ARCHIVED_ONLY = 2;
     // Return both archived and unarchived labels.
-    ARCHIVED_FILTER_NONE = 3;
+    ARCHIVE_FILTER_ALL = 3;
   }
   // The maximum number of items to return.
   //
@@ -134,10 +134,10 @@ message ListLabelsRequest {
   }];
   // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
-  // The archived filter on the returned Labels.
+  // The archive filter on the returned Labels.
   //
-  // If not specified, defaults to ARCHIVE_FILTER_ONLY_UNARCHIVED.
-  ArchivedFilter archived_filter = 7 [(buf.validate.field).enum.defined_only = true];
+  // If not specified, defaults to ARCHIVE_FILTER_UNARCHIVED_ONLY.
+  ArchiveFilter archive_filter = 7 [(buf.validate.field).enum.defined_only = true];
 }
 
 message ListLabelsResponse {

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -86,7 +86,7 @@ message ListLabelsRequest {
     // Order by create_time oldest to newest.
     ORDER_CREATE_TIME_ASC = 2;
   }
-  // The filter on the archived field of a Label.
+  // A filter on whether a Label is archived or not.
   enum ArchiveFilter {
     ARCHIVE_FILTER_UNSPECIFIED = 0;
     // Return only unarchived labels.

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -86,6 +86,16 @@ message ListLabelsRequest {
     // Order by create_time newest to oldest.
     ORDER_CREATE_TIME_DESC = 2;
   }
+  // The filter on the archived field of a Label.
+  enum ArchivedFilter {
+    ARCHIVED_FILTER_UNSPECIFIED = 0;
+    // Return only unarchived labels.
+    ARCHIVED_FILTER_ONLY_UNARCHIVED = 1;
+    // Return only archived labels.
+    ARCHIVED_FILTER_ONLY_ARCHIVED = 2;
+    // Return both archived and unarchived labels.
+    ARCHIVED_FILTER_NONE = 3;
+  }
   // The maximum number of items to return.
   //
   // The default value is 10.
@@ -123,6 +133,8 @@ message ListLabelsRequest {
   repeated CommitCheckStatus commit_check_statuses = 5 [(buf.validate.field).repeated.items.enum.defined_only = true];
   // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
+  // The archived filter on the returned Labels.
+  ArchivedFilter archived_filter = 7 [(buf.validate.field).enum.defined_only = true];
 }
 
 message ListLabelsResponse {

--- a/buf/registry/module/v1/module.proto
+++ b/buf/registry/module/v1/module.proto
@@ -71,8 +71,7 @@ message Module {
   // must have a Commit, so this Label is not created when a Module is created. Additionally,
   // a User may modify the name of the default Label without this Label yet being created.
   //
-  // This could also be the name of an archived Label. An important note, an archived Label
-  // will not be considered a valid ResourceRef for resolving a Module.
+  // This could also be the name of an archived Label.
   string default_label_name = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250

--- a/buf/registry/module/v1/module.proto
+++ b/buf/registry/module/v1/module.proto
@@ -72,8 +72,7 @@ message Module {
   // a User may modify the name of the default Label without this Label yet being created.
   //
   // This could also be the name of an archived Label. An important note, an archived Label
-  // will not be considered a valid ResourceRef for resolving a Module. Archived Labels
-  // can only be retrieved using LabelService.GetLabels.
+  // will not be considered a valid ResourceRef for resolving a Module.
   string default_label_name = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250

--- a/buf/registry/module/v1/resource.proto
+++ b/buf/registry/module/v1/resource.proto
@@ -47,8 +47,7 @@ message Resource {
 // ResourceRefs can only be used in requests, and only for read-only RPCs, that is
 // you should not use an arbitrary reference when modifying a specific resource.
 //
-// ResourceRefs cannot reference archived Labels. The only way to retrieve an archived Label
-// is to use LabelService.GetLabels.
+// ResourceRefs cannot reference archived Labels.
 message ResourceRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
   option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;

--- a/buf/registry/module/v1/resource.proto
+++ b/buf/registry/module/v1/resource.proto
@@ -46,8 +46,6 @@ message Resource {
 //
 // ResourceRefs can only be used in requests, and only for read-only RPCs, that is
 // you should not use an arbitrary reference when modifying a specific resource.
-//
-// ResourceRefs cannot reference archived Labels.
 message ResourceRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
   option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;

--- a/buf/registry/module/v1beta1/label.proto
+++ b/buf/registry/module/v1beta1/label.proto
@@ -40,7 +40,7 @@ message Label {
   // The time the Label was archived if it is currently archived.
   //
   // If this field is not set, the Label is not currently archived.
-  google.protobuf.Timestamp archived_time = 4;
+  google.protobuf.Timestamp archive_time = 4;
   // The name of the Label.
   //
   // Unique within a given Module.

--- a/buf/registry/module/v1beta1/label.proto
+++ b/buf/registry/module/v1beta1/label.proto
@@ -37,8 +37,10 @@ message Label {
   google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
   // The last time the Label was updated on the BSR.
   google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
-  // Whether or not the Label is archived.
-  bool archived = 4;
+  // The time the Label was archived if it is currently archived.
+  //
+  // If this field is not set, the Label is not currently archived.
+  google.protobuf.Timestamp archived_time = 4;
   // The name of the Label.
   //
   // Unique within a given Module.

--- a/buf/registry/module/v1beta1/label.proto
+++ b/buf/registry/module/v1beta1/label.proto
@@ -37,10 +37,7 @@ message Label {
   google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
   // The last time the Label was updated on the BSR.
   google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
-  // Whether or not the Label was archived.
-  //
-  // If a Label is archived, the API considers it to not exist and will not return archived
-  // Labels, except when calling LabelService.GetLabels.
+  // Whether or not the Label is archived.
   bool archived = 4;
   // The name of the Label.
   //

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -55,6 +55,12 @@ service LabelService {
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
   }
+  // Unarchive existing Labels.
+  //
+  // This operation is atomic. Either all Labels are unarchived or an error is returned.
+  rpc UnarchiveLabels(UnarchiveLabelsRequest) returns (UnarchiveLabelsResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
 }
 
 message GetLabelsRequest {
@@ -234,3 +240,13 @@ message ArchiveLabelsRequest {
 }
 
 message ArchiveLabelsResponse {}
+
+message UnarchiveLabelsRequest {
+  // The Labels to unarchive.
+  repeated LabelRef label_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message UnarchiveLabelsResponse {}

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -135,6 +135,8 @@ message ListLabelsRequest {
   // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
   // The archived filter on the returned Labels.
+  //
+  // If not specified, defaults to ARCHIVE_FILTER_ONLY_UNARCHIVED.
   ArchivedFilter archived_filter = 7 [(buf.validate.field).enum.defined_only = true];
 }
 

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -87,7 +87,7 @@ message ListLabelsRequest {
     // Order by create_time oldest to newest.
     ORDER_CREATE_TIME_ASC = 2;
   }
-  // The filter on the archived field of a Label.
+  // A filter on whether a Label is archived or not.
   enum ArchiveFilter {
     ARCHIVE_FILTER_UNSPECIFIED = 0;
     // Return only unarchived labels.

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -87,6 +87,16 @@ message ListLabelsRequest {
     // Order by create_time newest to oldest.
     ORDER_CREATE_TIME_DESC = 2;
   }
+  // The filter on the archived field of a Label.
+  enum ArchivedFilter {
+    ARCHIVED_FILTER_UNSPECIFIED = 0;
+    // Return only unarchived labels.
+    ARCHIVED_FILTER_ONLY_UNARCHIVED = 1;
+    // Return only archived labels.
+    ARCHIVED_FILTER_ONLY_ARCHIVED = 2;
+    // Return both archived and unarchived labels.
+    ARCHIVED_FILTER_NONE = 3;
+  }
   // The maximum number of items to return.
   //
   // The default value is 10.
@@ -124,6 +134,8 @@ message ListLabelsRequest {
   repeated CommitCheckStatus commit_check_statuses = 5 [(buf.validate.field).repeated.items.enum.defined_only = true];
   // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
+  // The archived filter on the returned Labels.
+  ArchivedFilter archived_filter = 7 [(buf.validate.field).enum.defined_only = true];
 }
 
 message ListLabelsResponse {

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -88,14 +88,14 @@ message ListLabelsRequest {
     ORDER_CREATE_TIME_ASC = 2;
   }
   // The filter on the archived field of a Label.
-  enum ArchivedFilter {
-    ARCHIVED_FILTER_UNSPECIFIED = 0;
+  enum ArchiveFilter {
+    ARCHIVE_FILTER_UNSPECIFIED = 0;
     // Return only unarchived labels.
-    ARCHIVED_FILTER_ONLY_UNARCHIVED = 1;
+    ARCHIVE_FILTER_UNARCHIVED_ONLY = 1;
     // Return only archived labels.
-    ARCHIVED_FILTER_ONLY_ARCHIVED = 2;
+    ARCHIVE_FILTER_ARCHIVED_ONLY = 2;
     // Return both archived and unarchived labels.
-    ARCHIVED_FILTER_NONE = 3;
+    ARCHIVE_FILTER_ALL = 3;
   }
   // The maximum number of items to return.
   //
@@ -135,10 +135,10 @@ message ListLabelsRequest {
   }];
   // Only return Labels with a name that contains this string using a case-insensitive comparison.
   string name_query = 6 [(buf.validate.field).string.max_len = 250];
-  // The archived filter on the returned Labels.
+  // The archive filter on the returned Labels.
   //
-  // If not specified, defaults to ARCHIVE_FILTER_ONLY_UNARCHIVED.
-  ArchivedFilter archived_filter = 7 [(buf.validate.field).enum.defined_only = true];
+  // If not specified, defaults to ARCHIVE_FILTER_UNARCHIVED_ONLY.
+  ArchiveFilter archive_filter = 7 [(buf.validate.field).enum.defined_only = true];
 }
 
 message ListLabelsResponse {

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -71,8 +71,7 @@ message Module {
   // must have a Commit, so this Label is not created when a Module is created. Additionally,
   // a User may modify the name of the default Label without this Label yet being created.
   //
-  // This could also be the name of an archived Label. An important note, an archived Label
-  // will not be considered a valid ResourceRef for resolving a Module.
+  // This could also be the name of an archived Label.
   string default_label_name = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -72,8 +72,7 @@ message Module {
   // a User may modify the name of the default Label without this Label yet being created.
   //
   // This could also be the name of an archived Label. An important note, an archived Label
-  // will not be considered a valid ResourceRef for resolving a Module. Archived Labels
-  // can only be retrieved using LabelService.GetLabels.
+  // will not be considered a valid ResourceRef for resolving a Module.
   string default_label_name = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -47,8 +47,7 @@ message Resource {
 // ResourceRefs can only be used in requests, and only for read-only RPCs, that is
 // you should not use an arbitrary reference when modifying a specific resource.
 //
-// ResourceRefs cannot reference archived Labels. The only way to retrieve an archived Label
-// is to use LabelService.GetLabels.
+// ResourceRefs cannot reference archived Labels.
 message ResourceRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
   option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;

--- a/buf/registry/module/v1beta1/resource.proto
+++ b/buf/registry/module/v1beta1/resource.proto
@@ -46,8 +46,6 @@ message Resource {
 //
 // ResourceRefs can only be used in requests, and only for read-only RPCs, that is
 // you should not use an arbitrary reference when modifying a specific resource.
-//
-// ResourceRefs cannot reference archived Labels.
 message ResourceRef {
   option (buf.registry.priv.extension.v1beta1.message).request_only = true;
   option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;


### PR DESCRIPTION
Behavior changes for archived labels:
1. Archived labels can be returned by any API.
2. Archived labels are now valid ResourceRefs.
3. Add explicit filter parameter to ListLabels so it can return only unarchived labels (the default), both archived and unarchived labels (needed by the UI), or only archived labels (could be useful for the future).
4. Add UnarchiveLabels RPC so the frontend can implement an "undo" button if someone accidentally archives a label (or wants to unarchive a label for any other reason).