### PR TITLE
Enable breaking change detection on main branch

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs:
       - lint
-      # - breaking
+      - breaking
     steps:
       - uses: actions/checkout@v4
       - name: Install buf cli


### PR DESCRIPTION
It was disabled so we could merge https://github.com/bufbuild/registry-proto/pull/95 and https://github.com/bufbuild/registry-proto/pull/92