### PR TITLE
Remove TODO for USER_VERIFICATION_STATUS_OFFICIAL

### DIFF
--- a/buf/registry/owner/v1/user.proto
+++ b/buf/registry/owner/v1/user.proto
@@ -97,7 +97,6 @@ enum UserVerificationStatus {
   // The User is verified.
   USER_VERIFICATION_STATUS_VERIFIED = 2;
   // The User is an official user of the BSR owner.
-  // TODO: should this exist?
   USER_VERIFICATION_STATUS_OFFICIAL = 3;
 }
 


### PR DESCRIPTION
This state exists in the backend so we are going to continue to support it.