### PR TITLE
Fix length for `id_query`

### DIFF
--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -86,7 +86,7 @@ message ListCommitsRequest {
   // If not specified, defaults to ORDER_CREATE_TIME_DESC.
   Order order = 4 [(buf.validate.field).enum.defined_only = true];
   // Only return Commits with an id that contains this string using a case-insensitive comparison.
-  string id_query = 5 [(buf.validate.field).string.max_len = 32];
+  string id_query = 5 [(buf.validate.field).string.max_len = 36];
 }
 
 message ListCommitsResponse {

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -101,7 +101,7 @@ message ListCommitsRequest {
   // If not set, the latest DigestType is used, currently B5.
   DigestType digest_type = 5 [(buf.validate.field).enum.defined_only = true];
   // Only return Commits with an id that contains this string using a case-insensitive comparison.
-  string id_query = 6 [(buf.validate.field).string.max_len = 32];
+  string id_query = 6 [(buf.validate.field).string.max_len = 36];
 }
 
 message ListCommitsResponse {


### PR DESCRIPTION
A dashful UUID is 36 chars long.