### PR TITLE
Document that id_query is dash insensitive

### DIFF
--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -85,7 +85,7 @@ message ListCommitsRequest {
   //
   // If not specified, defaults to ORDER_CREATE_TIME_DESC.
   Order order = 4 [(buf.validate.field).enum.defined_only = true];
-  // Only return Commits with an id that contains this string using a case-insensitive comparison.
+  // Only return Commits with an id that contains this string using a case-insensitive and dash-insensitive comparison.
   string id_query = 5 [(buf.validate.field).string.max_len = 36];
 }
 

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -100,7 +100,7 @@ message ListCommitsRequest {
   //
   // If not set, the latest DigestType is used, currently B5.
   DigestType digest_type = 5 [(buf.validate.field).enum.defined_only = true];
-  // Only return Commits with an id that contains this string using a case-insensitive comparison.
+  // Only return Commits with an id that contains this string using a case-insensitive and dash-insensitive comparison.
   string id_query = 6 [(buf.validate.field).string.max_len = 36];
 }
 


### PR DESCRIPTION
On the backend, we should effectively strip out dashes from the input and then do a case insensitive match against the dashless commit id.

For example:
id_query of `123-4` or `1234` should both match commits with ids that contain the any of the strings `1234`, `1-234`, `12-34`, `123-4`