### PR TITLE
Update Label.updated_by_user_id to be not required

### DIFF
--- a/buf/registry/module/v1/commit.proto
+++ b/buf/registry/module/v1/commit.proto
@@ -62,7 +62,10 @@ message Commit {
   // The id of the User that created this Commit on the BSR.
   //
   // May be empty if the User is no longer available.
-  string created_by_user_id = 6 [(buf.validate.field).string.tuuid = true];
+  string created_by_user_id = 6 [
+    (buf.validate.field).string.tuuid = true,
+    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+  ];
   // The URL of the source control commit that is associated with the Commit.
   //
   // BSR users can navigate to this link to find source control information that is relevant to this Commit

--- a/buf/registry/module/v1/label.proto
+++ b/buf/registry/module/v1/label.proto
@@ -67,10 +67,9 @@ message Label {
     (buf.validate.field).string.tuuid = true
   ];
   // The id of the User that last updated this Label on the BSR.
-  string updated_by_user_id = 9 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.tuuid = true
-  ];
+  //
+  // May be empty if the User is no longer available.
+  string updated_by_user_id = 9 [(buf.validate.field).string.tuuid = true];
   // The CommitCheckState for the Commit the Label points to.
   //
   // The CommitCheckStatus will always be disabled, passed, or approved, since Labels will

--- a/buf/registry/module/v1/label.proto
+++ b/buf/registry/module/v1/label.proto
@@ -69,7 +69,10 @@ message Label {
   // The id of the User that last updated this Label on the BSR.
   //
   // May be empty if the User is no longer available.
-  string updated_by_user_id = 9 [(buf.validate.field).string.tuuid = true];
+  string updated_by_user_id = 9 [
+    (buf.validate.field).string.tuuid = true,
+    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+  ];
   // The CommitCheckState for the Commit the Label points to.
   //
   // The CommitCheckStatus will always be disabled, passed, or approved, since Labels will

--- a/buf/registry/module/v1beta1/commit.proto
+++ b/buf/registry/module/v1beta1/commit.proto
@@ -62,7 +62,10 @@ message Commit {
   // The id of the User that created this Commit on the BSR.
   //
   // May be empty if the User is no longer available.
-  string created_by_user_id = 6 [(buf.validate.field).string.tuuid = true];
+  string created_by_user_id = 6 [
+    (buf.validate.field).string.tuuid = true,
+    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+  ];
   // The URL of the source control commit that is associated with the Commit.
   //
   // BSR users can navigate to this link to find source control information that is relevant to this Commit

--- a/buf/registry/module/v1beta1/label.proto
+++ b/buf/registry/module/v1beta1/label.proto
@@ -67,10 +67,9 @@ message Label {
     (buf.validate.field).string.tuuid = true
   ];
   // The id of the User that last updated this Label on the BSR.
-  string updated_by_user_id = 9 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.tuuid = true
-  ];
+  //
+  // May be empty if the User is no longer available.
+  string updated_by_user_id = 9 [(buf.validate.field).string.tuuid = true];
   // The CommitCheckState for the Commit the Label points to.
   //
   // The CommitCheckStatus will always be disabled, passed, or approved, since Labels will

--- a/buf/registry/module/v1beta1/label.proto
+++ b/buf/registry/module/v1beta1/label.proto
@@ -69,7 +69,10 @@ message Label {
   // The id of the User that last updated this Label on the BSR.
   //
   // May be empty if the User is no longer available.
-  string updated_by_user_id = 9 [(buf.validate.field).string.tuuid = true];
+  string updated_by_user_id = 9 [
+    (buf.validate.field).string.tuuid = true,
+    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+  ];
   // The CommitCheckState for the Commit the Label points to.
   //
   // The CommitCheckStatus will always be disabled, passed, or approved, since Labels will


### PR DESCRIPTION
Users can get deleted. This is consistent with the behavior already documented for Commit.created_by_user_id

https://github.com/bufbuild/registry-proto/blob/5a40a3fc390ac8316ca34c7776aa2f118be288b4/buf/registry/module/v1/commit.proto#L62-L65