### PR TITLE
Fix documentation and validation on `UpdateModulesRequest.default_label_name`

### DIFF
--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -168,8 +168,11 @@ message UpdateModulesRequest {
     //
     // This Label may not yet exist.
     //
-    // This may point to an archived Label.
-    optional string default_label_name = 7 [(buf.validate.field).string.max_len = 250];
+    // This may not point to an archived Label.
+    optional string default_label_name = 7 [
+      (buf.validate.field).string.min_len = 1,
+      (buf.validate.field).string.max_len = 250
+    ];
   }
   // The Modules to update.
   repeated Value values = 1 [

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -168,8 +168,11 @@ message UpdateModulesRequest {
     //
     // This Label may not yet exist.
     //
-    // This may point to an archived Label.
-    optional string default_label_name = 7 [(buf.validate.field).string.max_len = 250];
+    // This may not point to an archived Label.
+    optional string default_label_name = 7 [
+      (buf.validate.field).string.min_len = 1,
+      (buf.validate.field).string.max_len = 250
+    ];
   }
   // The Modules to update.
   repeated Value values = 1 [


### PR DESCRIPTION
If present, it must be non-empty and may not point to an archived label.