### PR TITLE
Clarify that filters are additive

### DIFF
--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -75,7 +75,7 @@ message ListCommitsRequest {
   //
   // See the documentation on Ref for resource resolution details.
   //
-  // Once the resource is resolved, the following Commits are listed:
+  // Once the resource is resolved, the following Commits are listed (subject to any additional filters in the request):
   //   - If a Module is referenced, all Commits for the Module are returned.
   //   - If a Label is referenced, the Commit the Label points to is returned.
   //     Use ListLabelHistory to get the history of Commits for a Label.

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -108,7 +108,7 @@ message ListLabelsRequest {
   //
   // See the documentation on Ref for resource resolution details.
   //
-  // Once the resource is resolved, the following Labels are listed:
+  // Once the resource is resolved, the following Labels are listed (subject to any additional filters in the request):
   //   - If a Module is referenced, all Labels for the Module are returned.
   //   - If a Label is referenced, this Label is returned.
   //   - If a Commit is referenced, all Labels that currently point to the Commit are returned. Note that

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -83,7 +83,7 @@ message ListCommitsRequest {
   //
   // See the documentation on Ref for resource resolution details.
   //
-  // Once the resource is resolved, the following Commits are listed:
+  // Once the resource is resolved, the following Commits are listed (subject to any additional filters in the request):
   //   - If a Module is referenced, all Commits for the Module are returned.
   //   - If a Label is referenced, the Commit the Label points to is returned.
   //     Use ListLabelHistory to get the history of Commits for a Label.

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -109,7 +109,7 @@ message ListLabelsRequest {
   //
   // See the documentation on Ref for resource resolution details.
   //
-  // Once the resource is resolved, the following Labels are listed:
+  // Once the resource is resolved, the following Labels are listed (subject to any additional filters in the request):
   //   - If a Module is referenced, all Labels for the Module are returned.
   //   - If a Label is referenced, this Label is returned.
   //   - If a Commit is referenced, all Labels that currently point to the Commit are returned. Note that


### PR DESCRIPTION
The documentation on ResourceRef for both List{Commits,Labels} is phrased in a way that could be confused to mean the endpoint always returns the specified results, but that doesn't make sense because there are additional filtering fields on each of these RPCs.

This PR updates the documentation to clarify that filter fields are additive (i.e. ANDed together) to the resource_ref filter.

Slack discussion: https://bufprivate.slack.com/archives/C02KXVDB23B/p1717182975280679