### PR TITLE
Update buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -5,10 +5,8 @@ deps:
 lint:
   use:
     - DEFAULT
-    - PACKAGE_NO_IMPORT_CYCLE
     - UNARY_RPC
   disallow_comment_ignores: true
 breaking:
   use:
     - WIRE_JSON
-  ignore_unstable_packages: true


### PR DESCRIPTION
- Remove `PACKAGE_NO_IMPORT_CYCLE` from the `use` list, as this is part of `DEFAULT` in `v2`.
- Enforce breaking changes on beta packages. Beta is a bit of a misnomer for us in this module.