### PR TITLE
Add ability to configure base ModuleRole for Organizations

### DIFF
--- a/buf/registry/owner/v1/organization.proto
+++ b/buf/registry/owner/v1/organization.proto
@@ -90,7 +90,7 @@ enum ModuleRole {
   MODULE_ROLE_WRITE = 3;
   // A role that has administrative access to the module.
   MODULE_ROLE_ADMIN = 4;
-  // A role that is the owner of the module.
+  // A role that has owner access to the module.
   MODULE_ROLE_OWNER = 5;
 }
 

--- a/buf/registry/owner/v1/organization.proto
+++ b/buf/registry/owner/v1/organization.proto
@@ -59,6 +59,13 @@ message Organization {
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
+  // The base role that Organization members have for repositories in the Organization.
+  ModuleRole module_base_role = 8 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true,
+    (buf.validate.field).enum.not_in = 0,
+    (buf.validate.field).enum.not_in = 5
+  ];
 }
 
 // The verification status of an Organization.
@@ -70,6 +77,21 @@ enum OrganizationVerificationStatus {
   ORGANIZATION_VERIFICATION_STATUS_VERIFIED = 2;
   // The Organization is an official organization of the BSR owner.
   ORGANIZATION_VERIFICATION_STATUS_OFFICIAL = 3;
+}
+
+// An access role to a module.
+enum ModuleRole {
+  MODULE_ROLE_UNSPECIFIED = 0;
+  // A role that has read access to the module.
+  MODULE_ROLE_READ = 1;
+  // A role that has limited write access to the module.
+  MODULE_ROLE_LIMITED_WRITE = 2;
+  // A role that has full write access to the module.
+  MODULE_ROLE_WRITE = 3;
+  // A role that has administrative access to the module.
+  MODULE_ROLE_ADMIN = 4;
+  // A role that is the owner of the module.
+  MODULE_ROLE_OWNER = 5;
 }
 
 // OrganizationRef is a reference to an Organization, either an id or a name.

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -152,6 +152,13 @@ message UpdateOrganizationsRequest {
     ];
     // The verification status of the Organization.
     optional OrganizationVerificationStatus verification_status = 4 [(buf.validate.field).enum.defined_only = true];
+
+    // The base role that Organization members have for repositories in the Organization.
+    optional ModuleRole module_base_role = 8 [
+      (buf.validate.field).enum.defined_only = true,
+      (buf.validate.field).enum.not_in = 0,
+      (buf.validate.field).enum.not_in = 5
+    ];
   }
   // The Organizations to update.
   repeated Value values = 1 [


### PR DESCRIPTION
We want to update the BSR web app to be able to configure the base role at creation time but the current v1 APIs don't support setting/changing this, so the current web UI is implemented by using v1 RPC to create and organization, and then an alpha API to immediately set the base role. It would be ideal if we could update the v1 API to support setting the base role at creation time.

This PR is to start a discussion about if, and how, we want to represent roles in the organization API. It is ok if the conclusion is we want to defer thinking about this until we think about roles more holistically.