### PR TITLE
Always use latest version of buf

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -15,4 +15,3 @@ jobs:
       - uses: bufbuild/buf-action@v0.1
         with:
           token: ${{ secrets.BUF_TOKEN }}
-          version: 1.32.2


### PR DESCRIPTION
It is more important for our repos to always track latest for dogfooding purposes.

This is [what we are going to do in bufbuild/buf](https://github.com/bufbuild/buf/pull/3071).