### PR TITLE
Add deprecation message to v1 and v1beta1 module

### DIFF
--- a/buf/registry/module/v1/module.proto
+++ b/buf/registry/module/v1/module.proto
@@ -76,6 +76,15 @@ message Module {
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250
   ];
+  // The message of deprecating the module. Typically a message redirecting readers
+  // to the module that should be used instead.
+  string deprecation_message = 11 [(buf.validate.field).string.max_len = 255];
+
+  option (buf.validate.message).cel = {
+    id: "deprecation_message_only_if_deprecated"
+    message: "deprecation message is set only if the module is deprecated"
+    expression: "this.deprecation_message == '' || this.state == 2" // 2 is MODULE_STATE_DEPRECATED
+  };
 }
 
 // The visibility of a Module, currently either public or private.

--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -134,6 +134,11 @@ message CreateModulesRequest {
     //
     // This may point to an archived Label.
     string default_label_name = 6 [(buf.validate.field).string.max_len = 250];
+    // The message for deprecating the module.
+    //
+    // This can only be set if this request deprecates the module or the
+    // module is already deprecated.
+    string deprecation_message = 7 [(buf.validate.field).string.max_len = 255];
   }
   // The Modules to create.
   repeated Value values = 1 [

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -76,6 +76,15 @@ message Module {
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250
   ];
+  // The message of deprecating the module. Typically a message redirecting readers
+  // to the module that should be used instead.
+  string deprecation_message = 11 [(buf.validate.field).string.max_len = 255];
+
+  option (buf.validate.message).cel = {
+    id: "deprecation_message_only_if_deprecated"
+    message: "deprecation message is set only if the module is deprecated"
+    expression: "this.deprecation_message == '' || this.state == 2" // 2 is MODULE_STATE_DEPRECATED
+  };
 }
 
 // The visibility of a Module, currently either public or private.

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -179,6 +179,11 @@ message UpdateModulesRequest {
       (buf.validate.field).string.min_len = 1,
       (buf.validate.field).string.max_len = 250
     ];
+    // The message for deprecating the module.
+    //
+    // This can only be set if this request deprecates the module or the
+    // module is already deprecated.
+    string deprecation_message = 8 [(buf.validate.field).string.max_len = 255];
   }
   // The Modules to update.
   repeated Value values = 1 [


### PR DESCRIPTION
This PR adds deprecation message to v1 and v1beta1 module, so that the CLI command that deprecates a module can use v1 API.