### PR TITLE
Use IGNORE_IF_DEFAULT_VALUE for URL fields in update requests

### DIFF
--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -168,7 +168,7 @@ message UpdateModulesRequest {
     optional string url = 6 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore_empty = true
+      (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
     ];
     // The name of the default Label of the Module.
     //

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -168,7 +168,7 @@ message UpdateModulesRequest {
     optional string url = 6 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore_empty = true
+      (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
     ];
     // The name of the default Label of the Module.
     //

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -148,7 +148,7 @@ message UpdateOrganizationsRequest {
     optional string url = 3 [
       (buf.validate.field).string.uri = true,
       (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore_empty = true
+      (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
     ];
     // The verification status of the Organization.
     optional OrganizationVerificationStatus verification_status = 4 [


### PR DESCRIPTION
This PR makes it possible to unset the URL of a organization/module, which has always been the intended behavior but wasn't possible because `protovalidate` would reject the empty string for not being a valid URL.

Changes `ignore_empty = true` to `ignore = IGNORE_IF_DEFAULT_VALUE`, see [docs on ignore](https://buf.build/bufbuild/protovalidate/docs/main:buf.validate#buf.validate.Ignore).