### PR TITLE
Fix code owner rule that got overwritten

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-/buf/ @bufdev
-/buf/ @nicksnyder
+/buf/ @bufdev @nicksnyder


### PR DESCRIPTION
Currently, the owner role on the first line is overwritten the second line, this PR fixes that.

From [GitHub's docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file):

> Order is important; the last matching pattern takes the most precedence.