### PR TITLE
Add error details for Upload and GetCommits

### DIFF
--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -54,6 +54,13 @@ message GetCommitsResponse {
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
 }
 
+// GetCommitsErrorDetails is the error details for the GetCommits RPC.
+message GetCommitsErrorDetails {
+  // This contains the resource_refs that the server is unable to find. This is populated
+  // when a non-found error is returned by the server.
+  repeated ResourceRef not_found_resource_refs = 1;
+}
+
 message ListCommitsRequest {
   // The list order.
   enum Order {

--- a/buf/registry/module/v1/upload_service.proto
+++ b/buf/registry/module/v1/upload_service.proto
@@ -83,3 +83,10 @@ message UploadResponse {
   // If nothing changed for a given reference, the existing Commit will be returned.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
 }
+
+// UploadErrorDetails is the error details for the Upload RPC.
+message UploadErrorDetails {
+  // This contains the dep_commit_ids that the server is unable to find. This is populated
+  // when a non-found error is returned by the server.
+  repeated string not_found_dep_commit_ids = 1;
+}

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -57,6 +57,11 @@ message GetCommitsRequest {
   DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
+message GetCommitsResponse {
+  // The found Commits in the same order as requested.
+  repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
 // GetCommitsErrorDetails is the error details for the GetCommits RPC.
 message GetCommitsErrorDetails {
   // This contains the resource_refs that the server is unable to find. This is populated

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -57,9 +57,11 @@ message GetCommitsRequest {
   DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
-message GetCommitsResponse {
-  // The found Commits in the same order as requested.
-  repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
+// GetCommitsErrorDetails is the error details for the GetCommits RPC.
+message GetCommitsErrorDetails {
+  // This contains the resource_refs that the server is unable to find. This is populated
+  // when a non-found error is returned by the server.
+  repeated ResourceRef not_found_resource_refs = 1;
 }
 
 message ListCommitsRequest {

--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -98,3 +98,19 @@ message UploadResponse {
   // If nothing changed for a given reference, the existing Commit will be returned.
   repeated Commit commits = 1 [(buf.validate.field).repeated.min_items = 1];
 }
+
+// UploadErrorDetails is the error details for the Upload RPC.
+message UploadErrorDetails {
+  message DepRef {
+    // The commit_id of the dependency.
+    string commit_id = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.tuuid = true
+    ];
+    // The registry hostname of the dependency.
+    string registry = 2 [(buf.validate.field).required = true];
+  }
+  // This contains the dep_refs that the server is unable to find. This is populated
+  // when a non-found error is returned by the server.
+  repeated string not_found_dep_refs = 1;
+}

--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -112,5 +112,5 @@ message UploadErrorDetails {
   }
   // This contains the dep_refs that the server is unable to find. This is populated
   // when a non-found error is returned by the server.
-  repeated string not_found_dep_refs = 1;
+  repeated DepRef not_found_dep_refs = 1;
 }


### PR DESCRIPTION
This adds error details for `Upload` and `GetCommits`. This change allows servers (at least the BSR) to return structured errors when multiple commit IDs or resource refs are not found (could be extended later to account for other types of errors).