### PR TITLE
Update deprecated lint category

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -4,7 +4,7 @@ deps:
   - buf.build/bufbuild/protovalidate
 lint:
   use:
-    - DEFAULT
+    - STANDARD
     - UNARY_RPC
   disallow_comment_ignores: true
 breaking:


### PR DESCRIPTION
Fixes the lint warning when running `make`

> WARN    Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.