### PR TITLE
Allow setting spdx_license_id in module upload

### DIFF
--- a/buf/registry/module/v1/commit.proto
+++ b/buf/registry/module/v1/commit.proto
@@ -75,4 +75,10 @@ message Commit {
     (buf.validate.field).string.max_len = 255,
     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
   ];
+  // The SPDX License Identifier of the Commit.
+  //
+  // May be empty if the SPDX License Identifier was not explicitly set during upload, if the
+  // license file was not present, or if it was not possible to detect the SPDX License Identifier
+  // from the license file.
+  string spdx_license_id = 8;
 }

--- a/buf/registry/module/v1/upload_service.proto
+++ b/buf/registry/module/v1/upload_service.proto
@@ -61,6 +61,9 @@ message UploadRequest {
       (buf.validate.field).string.max_len = 255,
       (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
     ];
+    // The SPDX License Identifier. If this field is not set, the SPDX License Identifier will be
+    // detected from the license file, if present.
+    string spdx_license_id = 5;
   }
   // The Contents of all references.
   repeated Content contents = 1 [(buf.validate.field).repeated.min_items = 1];


### PR DESCRIPTION
This PR adds `spdx_license_id` field to module `UploadRequest`. The goal is to offer users more control over the resulting spdx license identifier that gets exposed once a module has been published. Such as in Generated SDKs.

The intention is to add a `--spdx-license-id` flag (or `--license` if we wanted to keep it short) to the `buf push` command.

For this to be useful, we need to expand the spdx expression logic to support (in addition to the SPDX License List):

> a user defined license reference denoted by the LicenseRef-[idString]
> 
> ... idstring = 1*(ALPHA / DIGIT / "-" / "." )

[Reference](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/)