### PR TITLE
Add ResourceService for v1beta1 Plugins

### DIFF
--- a/buf/registry/plugin/v1beta1/resource_service.proto
+++ b/buf/registry/plugin/v1beta1/resource_service.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package buf.registry.plugin.v1beta1;
 
-import "buf/registry/plugin/v1beta1/digest.proto";
 import "buf/registry/plugin/v1beta1/resource.proto";
 import "buf/validate/validate.proto";
 
@@ -38,13 +37,6 @@ message GetResourcesRequest {
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
   ];
-  // The DigestType to use for Digests returned on Commits.
-  //
-  // If this DigestType is not available, an error is returned.
-  // Note that certain DigestTypes may be deprecated over time.
-  //
-  // If not set, the latest DigestType is used, currently P1.
-  DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
 message GetResourcesResponse {

--- a/buf/registry/plugin/v1beta1/resource_service.proto
+++ b/buf/registry/plugin/v1beta1/resource_service.proto
@@ -1,0 +1,53 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.plugin.v1beta1;
+
+import "buf/registry/plugin/v1beta1/digest.proto";
+import "buf/registry/plugin/v1beta1/resource.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
+
+// Operate on Resources.
+service ResourceService {
+  // Get Resources.
+  rpc GetResources(GetResourcesRequest) returns (GetResourcesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+message GetResourcesRequest {
+  // References to request a Resource for.
+  //
+  // See the documentation on ResourceRef for resource resolution details.
+  repeated ResourceRef resource_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+  // The DigestType to use for Digests returned on Commits.
+  //
+  // If this DigestType is not available, an error is returned.
+  // Note that certain DigestTypes may be deprecated over time.
+  //
+  // If not set, the latest DigestType is used, currently P1.
+  DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
+}
+
+message GetResourcesResponse {
+  // The found Resources in the same order as requested.
+  repeated Resource resources = 1 [(buf.validate.field).repeated.min_items = 1];
+}


### PR DESCRIPTION
This adds the `ResourceService` for the `buf.registry.plugin.v1beta1` Plugins package. Follows the service implementation in [Modules](https://github.com/bufbuild/registry-proto/pull/70). See https://github.com/bufbuild/registry-proto/pull/132 