### PR TITLE
Add CheckService to plugin.v1beta1

### DIFF
--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -73,7 +73,7 @@ message ListCommitsRequest {
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The reference to list Commits for.
   //
-  // See the documentation on Ref for resource resolution details.
+  // See the documentation on ResourceRef for resource resolution details.
   //
   // Once the resource is resolved, the following Commits are listed (subject to any additional filters in the request):
   //   - If a Module is referenced, all Commits for the Module are returned.

--- a/buf/registry/module/v1/commit_service.proto
+++ b/buf/registry/module/v1/commit_service.proto
@@ -73,7 +73,7 @@ message ListCommitsRequest {
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
   // The reference to list Commits for.
   //
-  // See the documentation on ResourceRef for resource resolution details.
+  // See the documentation on Ref for resource resolution details.
   //
   // Once the resource is resolved, the following Commits are listed (subject to any additional filters in the request):
   //   - If a Module is referenced, all Commits for the Module are returned.

--- a/buf/registry/plugin/v1beta1/check_service.proto
+++ b/buf/registry/plugin/v1beta1/check_service.proto
@@ -1,0 +1,98 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.plugin.v1beta1;
+
+import "buf/plugin/check/v1/category.proto";
+import "buf/plugin/check/v1/rule.proto";
+import "buf/registry/plugin/v1beta1/resource.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
+
+// Operate on Check plugins.
+service CheckService {
+  // List rules for a given plugin commit.
+  rpc ListRules(ListRulesRequest) returns (ListRulesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // List categories for a given plugin commit.
+  rpc ListCategories(ListCategoriesRequest) returns (ListCategoriesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+message ListRulesRequest {
+  // The maximum number of items to return.
+  //
+  // The default value is 10.
+  uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
+  // The page to start from.
+  //
+  // If empty, the first page is returned.
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
+  // The reference to get rules for.
+  //
+  // See the documentation on ResourceRef for resource resolution details.
+  //
+  // Once the resource is resolved, the following rules are returned:
+  //   - If a Plugin is referenced, the rules of the the default Label are returned.
+  //   - If a Label is referenced, the rules of the Commit of this Label are returned.
+  //   - If a Commit is referenced, the rules for this commit are returned.
+  ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
+}
+
+// A response containing the rules that the plugin commit implements.
+message ListRulesResponse {
+  // The next page token.
+  //
+  // If empty, there are no more pages.
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
+  // The rules that the plugin implements. This is part of the Bufplugin API,
+  // and can be returned from a plugin's ListRules implementation.
+  repeated buf.plugin.check.v1.Rule rules = 2;
+}
+
+message ListCategoriesRequest {
+  // The maximum number of items to return.
+  //
+  // The default value is 10.
+  uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
+  // The page to start from.
+  //
+  // If empty, the first page is returned.
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
+  // The reference to get categories for.
+  //
+  // See the documentation on ResourceRef for resource resolution details.
+  //
+  // Once the resource is resolved, the following categories are returned:
+  //   - If a Plugin is referenced, the categories of the the default Label are returned.
+  //   - If a Label is referenced, the categories of the Commit of this Label are returned.
+  //   - If a Commit is referenced, the categories for this commit are returned.
+  ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
+}
+
+// A response containing the categories that the Plugin implements.
+message ListCategoriesResponse {
+  // The next page token.
+  //
+  // If empty, there are no more pages.
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
+  // The categories that the plugin implements. This is part of the Bufplugin API,
+  // and can be returned from a plugin's ListCategories implementation.
+  repeated buf.plugin.check.v1.Category categories = 2;
+}

--- a/buf/registry/plugin/v1beta1/check_service.proto
+++ b/buf/registry/plugin/v1beta1/check_service.proto
@@ -25,11 +25,11 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 
 // Operate on Check plugins.
 service CheckService {
-  // List rules for a given plugin commit.
+  // List Rules for a given Plugin, Label, or Commit.
   rpc ListRules(ListRulesRequest) returns (ListRulesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // List categories for a given plugin commit.
+  // List Categories for a given Plugin, Label, or Commit.
   rpc ListCategories(ListCategoriesRequest) returns (ListCategoriesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
@@ -44,25 +44,24 @@ message ListRulesRequest {
   //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
-  // The reference to get rules for.
+  // The reference to get Rules for.
   //
   // See the documentation on ResourceRef for resource resolution details.
   //
-  // Once the resource is resolved, the following rules are returned:
-  //   - If a Plugin is referenced, the rules of the the default Label are returned.
-  //   - If a Label is referenced, the rules of the Commit of this Label are returned.
-  //   - If a Commit is referenced, the rules for this commit are returned.
+  // Once the resource is resolved, the following Rules are returned:
+  //   - If a Plugin is referenced, the Rules of the the default Label are returned.
+  //   - If a Label is referenced, the Rules of the Commit of this Label are returned.
+  //   - If a Commit is referenced, the Rules for this Commit are returned.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 
-// A response containing the rules that the plugin commit implements.
 message ListRulesResponse {
   // The next page token.
   //
   // If empty, there are no more pages.
   string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
-  // The rules that the plugin implements. This is part of the Bufplugin API,
-  // and can be returned from a plugin's ListRules implementation.
+  // The listed Rules. This is part of the Bufplugin API, and can be returned from
+  // a plugin's ListRules implementation.
   repeated buf.plugin.check.v1.Rule rules = 2;
 }
 
@@ -75,24 +74,23 @@ message ListCategoriesRequest {
   //
   // If empty, the first page is returned.
   string page_token = 2 [(buf.validate.field).string.max_len = 4096];
-  // The reference to get categories for.
+  // The reference to get Categories for.
   //
   // See the documentation on ResourceRef for resource resolution details.
   //
-  // Once the resource is resolved, the following categories are returned:
-  //   - If a Plugin is referenced, the categories of the the default Label are returned.
-  //   - If a Label is referenced, the categories of the Commit of this Label are returned.
-  //   - If a Commit is referenced, the categories for this commit are returned.
+  // Once the resource is resolved, the following Categories are returned:
+  //   - If a Plugin is referenced, the Categories of the the default Label are returned.
+  //   - If a Label is referenced, the Categories of the Commit of this Label are returned.
+  //   - If a Commit is referenced, the Categories for this Commit are returned.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
 }
 
-// A response containing the categories that the Plugin implements.
 message ListCategoriesResponse {
   // The next page token.
   //
   // If empty, there are no more pages.
   string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
-  // The categories that the plugin implements. This is part of the Bufplugin API,
-  // and can be returned from a plugin's ListCategories implementation.
+  // The listed Categories. This is part of the Bufplugin API, and can be returned from
+  // a plugin's ListCategories implementation.
   repeated buf.plugin.check.v1.Category categories = 2;
 }


### PR DESCRIPTION
This PR adds a `CheckService` that takes a`ResourceRef` to allow API callers to fetch rules/categories for a plugin (latest commit on default label), label (latest commit) or commit.

For a moment, I thought _just maybe_ we could ask callers to download the wasm blob and invoke it instead, but I suspect we're not there yet. We need some way to get the rules/categories cheaply.