### PR TITLE
Add initial Policy specification

### DIFF
--- a/buf/registry/policy/v1beta1/configuration.proto
+++ b/buf/registry/policy/v1beta1/configuration.proto
@@ -1,0 +1,144 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// The Configuration of a specific Policy at a specific Version. This consists of the built-in
+// rules version and lint, breaking, and plugin configurations required to run the Policy.
+message Configuration {
+  // The built-in rules version. This specifies which version of built-in rules to use for the Policy.
+  enum BuiltInVersion {
+    BUILT_IN_VERSION_UNSPECIFIED = 0;
+    BUILT_IN_VERSION_V1BETA1 = 1;
+    BUILT_IN_VERSION_V1 = 2;
+    BUILT_IN_VERSION_V2 = 3;
+  }
+  // A check config represents the shared configurations for checks (e.g. lint and breaking).
+  message CheckConfig {
+    // The list of check rules and/or categories used for the Policy.
+    repeated string use = 1 [
+      (buf.validate.field).repeated.items = {
+        string: {
+          min_len: 2
+          max_len: 250
+        }
+      },
+      (buf.validate.field).repeated.max_items = 250
+    ];
+    // The list of check rules and/or categories to exclude for the Policy.
+    repeated string except = 2 [
+      (buf.validate.field).repeated.items = {
+        string: {
+          min_len: 2
+          max_len: 250
+        }
+      },
+      (buf.validate.field).repeated.max_items = 250
+    ];
+  }
+  // A lint config consists of the generic check config and additional lint-specifc configs
+  // required for running lint.
+  message LintConfig {
+    // The check config.
+    CheckConfig check_config = 1;
+    // The suffix that controls the behavior of the ENUM_ZERO_VALUE_SUFFIX lint rule. By default,
+    // this rule verifies that the zero value of all enums ends in `_UNSPECIFIED`, however, this
+    // allows organizations to choose a different suffix.
+    string enum_zero_value_suffix = 2 [(buf.validate.field).string.max_len = 250];
+    // This bool allows the same message type to be used for a single RPC's request and response type.
+    bool rpc_allow_same_request_response = 3;
+    // This bool allows RPC requests to be google.protobuf.Empty messages.
+    bool rpc_allow_google_protobuf_empty_requests = 4;
+    // This bool allows RPC responses to be google.protobuf.Empty messages.
+    bool rpc_allow_google_protobuf_empty_responses = 5;
+    // This suffix controls the behavior of the SERVICE_SUFFIX lint rule. By default, this rule
+    // verifies that all service names are suffixed with `Service`, however this allows organizations
+    // to choose a different suffix.
+    string service_suffix = 6 [(buf.validate.field).string.max_len = 250];
+  }
+  // A breaking config consists of the generic check config and additional breaking-specifc configs
+  // required for running breaking change detection.
+  message BreakingConfig {
+    // The check config.
+    CheckConfig check_cofnig = 1;
+    // This bool determines whether to ignore unstable packages for breaking change detection:
+    //   - v\d+test.*
+    //   - v\d+(alpha|beta)\d*
+    //   - v\d+p\d+(alpha|beta)\d*
+    bool ignore_unstable_packages = 2;
+  }
+  // A plugin config consists of the configs for invoking a check plugin.
+  message CheckPluginConfig {
+    // The fully-qualified name of a check Plugin within a BSR instance.
+    //
+    // A Name uniquely identifies a Plugin.
+    message Name {
+      // The name of the Organization owner.
+      string owner = 1 [
+        (buf.validate.field).required = true,
+        (buf.validate.field).string.max_len = 32
+      ];
+      // The name of the Plugin.
+      string plugin = 2 [(buf.validate.field).string = {
+        min_len: 2
+        max_len: 100
+      }];
+    }
+    // A Plugin option. This consists of a key and value.
+    message Option {
+      string key = 1 [(buf.validate.field).string = {
+        min_len: 2
+        max_len: 100
+      }];
+      string value = 2 [(buf.validate.field).string = {
+        min_len: 2
+        max_len: 100
+      }];
+    }
+    // The Plugin name.
+    Name name = 1 [(buf.validate.field).required = true];
+    // The ref to a specific Plugin commit. This could be a label name or a commit ID.
+    // If no reference is set, then at the time of running the Policy, the latest commit on
+    // the default label of the Plugin is used.
+    //
+    // If this value is present but empty, this should be treated as not present.
+    string ref = 2 [(buf.validate.field).string.max_len = 250];
+    // The options to invoke with the Plugin.
+    repeated Option options = 3 [(buf.validate.field).repeated.max_items = 250];
+    // The arguments to invoke with the Plugin.
+    repeated string args = 4 [
+      (buf.validate.field).repeated.items = {
+        string: {
+          min_len: 2
+          max_len: 250
+        }
+      },
+      (buf.validate.field).repeated.max_items = 250
+    ];
+  }
+  // The builtin lint and breaking rules version to use.
+  BuiltInVersion built_in_version = 1;
+  // The lint config.
+  LintConfig lint_config = 2;
+  // The breaking config.
+  BreakingConfig breaking_config = 3;
+  // The plugin configs.
+  repeated CheckPluginConfig check_plugin_configs = 4;
+}

--- a/buf/registry/policy/v1beta1/configuration_service.proto
+++ b/buf/registry/policy/v1beta1/configuration_service.proto
@@ -1,0 +1,52 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/policy/v1beta1/configuration.proto";
+import "buf/registry/policy/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// Operate on Policy Configruations.
+service ConfigurationService {
+  // Get Configurations for the given Policy or Version.
+  rpc GetConfigurations(GetConfigurationsRequest) returns (GetConfigurationsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+message GetConfigurationsRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The references to get Configurations for.
+  //
+  // See the documentation on ResourceRef for resource resolution details.
+  //
+  // Once the resource is resolved, the following Configurations are returned:
+  //   - If a Policy is referenced, the Configurations of the latest Version are returned.
+  //   - If a Version is referenced, the Configurations of that Version are returned.
+  repeated ResourceRef resource_ref = 1 [(buf.validate.field).required = true];
+}
+
+message GetConfigurationsResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The found Configurations in the same order as requested.
+  repeated Configuration configurations = 1 [(buf.validate.field).repeated.min_items = 1];
+}

--- a/buf/registry/policy/v1beta1/policy.proto
+++ b/buf/registry/policy/v1beta1/policy.proto
@@ -1,0 +1,113 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// A policy within the BSR.
+message Policy {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The id of the Policy.
+  string id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The time the Policy was created in the BSR.
+  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  // The last time the Policy was updated on the BSR.
+  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  // The name of the Policy.
+  //
+  // Unique within a given Organization.
+  string name = 4 [(buf.validate.field).string = {
+    min_len: 2
+    max_len: 100
+  }];
+  // The id of the Organization that owns the Policy.
+  string owner_id = 5 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The Policy's visibility, either public or private.
+  PolicyVisibility visibility = 6 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+  // The Policy state, either active or deprecated.
+  PolicyState state = 7 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+  // The configurable description of the Policy.
+  string desription = 8 [(buf.validate.field).string.max_len = 350];
+}
+
+// The visibility of a Policy, currently either public or private.
+enum PolicyVisibility {
+  POLICY_VISIBILITY_UNSPECIFIED = 0;
+  // POLICY_VISIBILITY_PUBLIC says that the Policy is publicly available.
+  POLICY_VISIBILITY_PUBLIC = 1;
+  // POLICY_VISIBILITY_PRIVATE says that the Policy is private.
+  POLICY_VISIBILITY_PRIVATE = 2;
+}
+
+// The state of a Policy, currently either active or deprecated.
+enum PolicyState {
+  POLICY_STATE_UNSPECIFIED = 0;
+  // POLICY_STATE_ACTIVE says that the Policy is currently active.
+  POLICY_STATE_ACTIVE = 1;
+  // POLICY_STATE_DEPRECATED says that the Policy has been deprecated and should not longer be
+  // used.
+  POLICY_STATE_DEPRECATED = 2;
+}
+
+// PolicyRef is a reference to a Policy, either an id or a fully-qualified name.
+//
+// This is used in requests.
+message PolicyRef {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The fully-qualified name of a Policy within a BSR intance.
+  //
+  // A Name uniquely identifies a Policy.
+  // This is used for requests when a caller only has the policy name and not the ID.
+  message Name {
+    // The name of the owner of the Policy. The owner is always an Organization.
+    string owner = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 32
+    ];
+    // The name of the Policy.
+    string policy = 2 [(buf.validate.field).string = {
+      min_len: 2
+      max_len: 100
+    }];
+  }
+
+  oneof value {
+    option (buf.validate.oneof).required = true;
+    // The id of the Policy.
+    string id = 1 [(buf.validate.field).string.tuuid = true];
+    // The full-qualified name of the Policy.
+    Name name = 2;
+  }
+}

--- a/buf/registry/policy/v1beta1/policy_service.proto
+++ b/buf/registry/policy/v1beta1/policy_service.proto
@@ -1,0 +1,194 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/owner/v1/owner.proto";
+import "buf/registry/policy/v1beta1/policy.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// Operate on Policies.
+service PolicyService {
+  // Get Policies by id or name.
+  rpc GetPolicies(GetPoliciesRequest) returns (GetPoliciesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // List Policies, usually for a specific User or Organization.
+  rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // Create new Policies.
+  //
+  // This operation is atomic. Either all Policies are created or an error is returned.
+  rpc CreatePolicies(CreatePoliciesRequest) returns (CreatePoliciesResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  // Update exiting Policies.
+  //
+  // This operation is atomic. Either all Policies are updated or an error is returned.
+  rpc UpdatePolicies(UpdatePoliciesRequest) returns (UpdatePoliciesResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  // Delete existing Policies.
+  //
+  // This operation is atomic. Either all Policies are deleted or an error is returned.
+  rpc DeletePolicies(DeletePoliciesRequest) returns (DeletePoliciesResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+}
+
+message GetPoliciesRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The Policies to request.
+  repeated PolicyRef policy_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message GetPoliciesResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The retrieved Policies in the same order as requested.
+  repeated Policy policies = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message ListPoliciesRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The list order.
+  enum Order {
+    ORDER_UNSPECIFIED = 0;
+    // Order by create_time newest to oldest.
+    ORDER_CREATE_TIME_DESC = 1;
+    // Order by create_time oldest to newest.
+    ORDER_CREATE_TIME_ASC = 2;
+  }
+  // The maximum number of items to return.
+  //
+  // The default value is 10.
+  uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
+  // The page to start from.
+  //
+  // If empty, the first page is returned.
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
+  // The specific Users or Organizations to list Policies for.
+  //
+  // If empty, all Policies for all owners are listed, but this functionality
+  // is limited to Users with the necessary permissions.
+  repeated buf.registry.owner.v1.OwnerRef owner_refs = 3;
+  // The order to return the Policies.
+  //
+  // If not specified, defaults to ORDER_CREATE_TIME_DESC.
+  Order order = 4 [(buf.validate.field).enum.defined_only = true];
+}
+
+message ListPoliciesResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The next page token.
+  //
+  // If empty, there are no more pages.
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
+  // The listed Policies.
+  repeated Policy policies = 2;
+}
+
+message CreatePoliciesRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // An individual request to create a Policy.
+  message Value {
+    // The User or Organization to create the Policy under.
+    buf.registry.owner.v1.OwnerRef owner_ref = 1 [(buf.validate.field).required = true];
+    // The name of the Policy.
+    string name = 2 [(buf.validate.field).string = {
+      min_len: 2
+      max_len: 100
+    }];
+    // The Policy's visibility.
+    PolicyVisibility visibility = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).enum.defined_only = true
+    ];
+    // The configurable description of the Policy.
+    string description = 4 [(buf.validate.field).string.max_len = 350];
+  }
+  // The Policies to create.
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message CreatePoliciesResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The created Policies in the same order as given on the request.
+  repeated Policy policies = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message UpdatePoliciesRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // An individual request to update a Policy.
+  message Value {
+    // The Policy to update.
+    PolicyRef policy_ref = 1 [(buf.validate.field).required = true];
+    // The Policy's visibility.
+    optional PolicyVisibility visibility = 2 [
+      (buf.validate.field).enum.defined_only = true,
+      (buf.validate.field).enum.not_in = 0
+    ];
+    // The deprecation status of the Policy.
+    optional PolicyState state = 4 [
+      (buf.validate.field).enum.defined_only = true,
+      (buf.validate.field).enum.not_in = 0
+    ];
+    // The configurable description of the Policy.
+    optional string description = 5 [(buf.validate.field).string.max_len = 350];
+  }
+  // The Policies to update.
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message UpdatePoliciesResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The updated Policies in the same order as given in the request.
+  repeated Policy policies = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message DeletePoliciesRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The Policies to delete.
+  repeated PolicyRef policy_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message DeletePoliciesResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+}

--- a/buf/registry/policy/v1beta1/resource.proto
+++ b/buf/registry/policy/v1beta1/resource.proto
@@ -1,0 +1,94 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/policy/v1beta1/policy.proto";
+import "buf/registry/policy/v1beta1/version.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// A Policy or Version.
+message Resource {
+  oneof value {
+    option (buf.validate.oneof).required = true;
+
+    Policy policy = 1;
+    Version version = 2;
+  }
+}
+
+// A reference to any of:
+//   - Policy
+//   - Version
+//
+// The id or name is resolved to a specific resource.
+// If an id is passed, this is interpreted as being the id of the resource.
+// If a name is passed, the semantics according to ResourceRef.Name are applied.
+//
+// ResourceRefs can only be used in requests, and only for read-only RPCs, that is
+// you should not use an arbitrary reference when modifying a specific resource.
+message ResourceRef {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+  option (buf.registry.priv.extension.v1beta1.message).no_side_effects_only = true;
+
+  // The fully-qualified name component of ResourceRef.
+  //
+  // The following semantics are applied:
+  //   - If the child oneof is not specified, the name is interpreted to reference a Policy.
+  //   - If version_id is specified, the name is interpreted to reference a Version with the
+  //     specified name.
+  //   - If version_number is specified, the name is interpreted to reference a Version with
+  //     the specified number.
+  //
+  // Names can only be used in requests, and only for read-only RPCs, that is
+  // you should not use an arbitrary reference when modifying a specific resource.
+  message Name {
+    // The name of the Organization that owns the resource.
+    string owner = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 32
+    ];
+    // The name of the Policy that contains or is the resource.
+    string policy = 2 [(buf.validate.field).string = {
+      min_len: 2
+      max_len: 100
+    }];
+    // If the oneof is present but empty, this should be treated as not present.
+    oneof child {
+      // The id of the Version.
+      //
+      // If this value is present but empty, this should be treated as not present, that is
+      // an empty value is the same as a null value.
+      string version_id = 3;
+      // The number of the Version.
+      //
+      // If this value is present but empty, this should be treated as not present, that is
+      // an empty value is the same as a null value.
+      uint32 version_number = 4;
+    }
+  }
+
+  oneof value {
+    option (buf.validate.oneof).required = true;
+    // The id of the resource.
+    string id = 1 [(buf.validate.field).string.tuuid = true];
+    // The fully-qualified name of the resource.
+    Name name = 2;
+  }
+}

--- a/buf/registry/policy/v1beta1/resource_service.proto
+++ b/buf/registry/policy/v1beta1/resource_service.proto
@@ -1,0 +1,49 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/policy/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+service ResourceService {
+  // Get Resources.
+  rpc GetResources(GetResourcesRequest) returns (GetResourcesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+message GetResourcesRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // References to request a Resource for.
+  //
+  // See the documentation on ResourceRef for resource resolution details.
+  repeated ResourceRef resource_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message GetResourcesResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The found Resources in the same order as requested.
+  repeated Resource resources = 1 [(buf.validate.field).repeated.min_items = 1];
+}

--- a/buf/registry/policy/v1beta1/upload_service.proto
+++ b/buf/registry/policy/v1beta1/upload_service.proto
@@ -1,0 +1,58 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/policy/v1beta1/configuration.proto";
+import "buf/registry/policy/v1beta1/policy.proto";
+import "buf/registry/policy/v1beta1/version.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// Upload contents.
+service UploadService {
+  // Upload contents for given set of Policies.
+  //
+  // Contents are expected to be a Configuration.
+  rpc Upload(UploadRequest) returns (UploadResponse) {}
+}
+
+message UploadRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // Content to upload.
+  message Content {
+    // The Policy of the reference.
+    PolicyRef policy_ref = 1 [(buf.validate.field).required = true];
+    // The Configuration of the Content.
+    Configuration configuration = 2 [(buf.validate.field).required = true];
+  }
+  // The Contents of all references.
+  repeated Content contents = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message UploadResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The Versions for each reference in the same order as given on the request.
+  //
+  // A single Version will be returned for each reference. These Versions may or may not be new.
+  // If nothing changed for a given reference (e.g. the same Configuration as the latest), the
+  // existing Version will be returned.
+  repeated Version versions = 1 [(buf.validate.field).repeated.min_items = 1];
+}

--- a/buf/registry/policy/v1beta1/version.proto
+++ b/buf/registry/policy/v1beta1/version.proto
@@ -1,0 +1,59 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// A version on a specific Policy.
+//
+// Versions are immutable.
+message Version {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The id of the Version.
+  string id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The autoincremented Version number.
+  uint32 number = 2 [(buf.validate.field).required = true];
+  // The time the Version was pushed to the BSR.
+  //
+  // Versions are immutable, so there is no corresponding update_time.
+  google.protobuf.Timestamp create_time = 3 [(buf.validate.field).required = true];
+  // The id of the Organization that owns the Policy that the Version is associated with.
+  string owner_id = 4 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The id of the Policy that the Version is associated with.
+  string policy_id = 5 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The id of the User that created this Version on the BSR.
+  //
+  // May be empty if the User is no longer available.
+  string created_by_user_id = 6 [
+    (buf.validate.field).string.tuuid = true,
+    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+  ];
+}

--- a/buf/registry/policy/v1beta1/version_service.proto
+++ b/buf/registry/policy/v1beta1/version_service.proto
@@ -1,0 +1,103 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/registry/policy/v1beta1/resource.proto";
+import "buf/registry/policy/v1beta1/version.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// Operate on Versions.
+service VersionService {
+  // Get Versions.
+  rpc GetVersions(GetVersionsRequest) returns (GetVersionsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // List Versions for a given Policy.
+  rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+message GetVersionsRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // References to request a Version for.
+  //
+  // See the documentation on ResourceRef for resource resolution details.
+  //
+  // Resolution is as follows:
+  //   - If a Policy is referenced, the latest Version of the Policy is returned.
+  //   - If a Version is referenced, then the Version is returned.
+  repeated ResourceRef resource_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message GetVersionsResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The found Versions in the same order as requested.
+  repeated Version versions = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message ListVersionsRequest {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The list order.
+  enum Order {
+    ORDER_UNSPECIFIED = 0;
+    // Order by create_time newest to oldest.
+    ORDER_CREATE_TIME_DESC = 1;
+    // Order by create_time from oldest to newest.
+    ORDER_CREATE_TIME_ASC = 2;
+  }
+  // The maximum number of items to return.
+  //
+  // The default is 10.
+  uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
+  // The page to start from.
+  //
+  // If empty, the first page is returned.
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
+  // The reference to list Versions for.
+  //
+  // See the documentation on Ref for resource resolution details.
+  //
+  // Once the resource is resolved, the following Versions are listed (subject to any additional filters in the request):
+  //   - If a Policy is referenced, all Versions for the Policy are returned.
+  //   - If a Version is referenced, the Version is returned.
+  ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
+  // The order to return the Versions.
+  //
+  // If not specified, defaults to ORDER_CREATE_TIME_DESC.
+  Order order = 4 [(buf.validate.field).enum.defined_only = true];
+}
+
+message ListVersionsResponse {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The next page token.
+  //
+  // If empty, there are no more pages.
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
+  // The listed Versions.
+  repeated Version versions = 2;
+}


### PR DESCRIPTION
This PR adds support for "check policies" as a feature in our API.

A new entity, `Policy` is added. Policies can only be owned by organizations,
and are in the same namespace as modules and plugins. A policy has immutable
versions (`Version`) and each version represents a `Configuration` of the `Policy`.

Uploading a new `Configuration` of a `Policy` will increment its `Version`. If the same
`Configuration` is uploaded, then the current latest `Version` is returned.