### PR TITLE
Fix list resources by CommitDigest to Label

### DIFF
--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -29,7 +29,7 @@ service LabelService {
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // List Labels for a given Module, Commit, or CommitDigest.
+  // List Labels for a given Module, Commit or Label.
   rpc ListLabels(ListLabelsRequest) returns (ListLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -30,7 +30,7 @@ service LabelService {
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // List Labels for a given Module, Commit, or CommitDigest.
+  // List Labels for a given Module, Commit or Label.
   rpc ListLabels(ListLabelsRequest) returns (ListLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }

--- a/buf/registry/plugin/v1beta1/label_service.proto
+++ b/buf/registry/plugin/v1beta1/label_service.proto
@@ -30,7 +30,7 @@ service LabelService {
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // List Labels for a given Plugin, Commit, or CommitDigest.
+  // List Labels for a given Plugin, Commit or Label.
   rpc ListLabels(ListLabelsRequest) returns (ListLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }


### PR DESCRIPTION
This fixes a typo for the non existant type CommitDigest and replaces it with Label.