### PR TITLE
Add Digests to Policies

### DIFF
--- a/buf/registry/plugin/v1beta1/commit.proto
+++ b/buf/registry/plugin/v1beta1/commit.proto
@@ -30,7 +30,7 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 //
 // Many Commits may be associated with one Digest.
 //
-// Not that the Digest returned on a Commit depends on the requested DigestType in the RPC that
+// Note that the Digest returned on a Commit depends on the requested DigestType in the RPC that
 // returned the Commit.
 message Commit {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;

--- a/buf/registry/plugin/v1beta1/commit_service.proto
+++ b/buf/registry/plugin/v1beta1/commit_service.proto
@@ -53,7 +53,7 @@ message GetCommitsRequest {
   // If this DigestType is not available, an error is returned.
   // Note that certain DigestTypes may be deprecated over time.
   //
-  // If not set, the latest DigestType is used, currently p1.
+  // If not set, the latest DigestType is used, currently P1.
   DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
 }
 

--- a/buf/registry/plugin/v1beta1/label_service.proto
+++ b/buf/registry/plugin/v1beta1/label_service.proto
@@ -173,7 +173,7 @@ message ListLabelHistoryRequest {
   // If this DigestType is not available, an error is returned. Note that certain DigestTypes may be
   // deprecated over time.
   //
-  // If not set, the latest DigestType is used, currently B5.
+  // If not set, the latest DigestType is used, currently P1.
   DigestType digest_type = 5 [(buf.validate.field).enum.defined_only = true];
   // The Commit id to start from.
   //

--- a/buf/registry/policy/v1beta1/commit.proto
+++ b/buf/registry/policy/v1beta1/commit.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package buf.registry.policy.v1beta1;
 
+import "buf/registry/policy/v1beta1/digest.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
@@ -25,6 +26,11 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 // A Commit on a specific Policy.
 //
 // Commits are immutable.
+//
+// Many Commits may be associated with one Digest.
+//
+// Note that the Digest returned on a Commit depends on the requested DigestType in the RPC that
+// returned the Commit.
 message Commit {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
@@ -47,6 +53,8 @@ message Commit {
     (buf.validate.field).required = true,
     (buf.validate.field).string.tuuid = true
   ];
+  // The Digest of the Commit's contents.
+  Digest digest = 6 [(buf.validate.field).required = true];
   // The id of the User that created this Commit on the BSR.
   //
   // May be empty if the User is no longer available.

--- a/buf/registry/policy/v1beta1/commit_service.proto
+++ b/buf/registry/policy/v1beta1/commit_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package buf.registry.policy.v1beta1;
 
 import "buf/registry/policy/v1beta1/commit.proto";
+import "buf/registry/policy/v1beta1/digest.proto";
 import "buf/registry/policy/v1beta1/resource.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
@@ -49,6 +50,13 @@ message GetCommitsRequest {
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 250
   ];
+  // The DigestType to use for Digests returned on Commits.
+  //
+  // If this DigestType is not available, an error is returned.
+  // Note that certain DigestTypes may be deprecated over time.
+  //
+  // If not set, the latest DigestType is used, currently P1.
+  DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
 message GetCommitsResponse {
@@ -91,6 +99,13 @@ message ListCommitsRequest {
   //
   // If not specified, defaults to ORDER_CREATE_TIME_DESC.
   Order order = 4 [(buf.validate.field).enum.defined_only = true];
+  // The DigestType to use for Digests returned on Commits.
+  //
+  // If this DigestType is not available, an error is returned.
+  // Note that certain DigestTypes may be deprecated over time.
+  //
+  // If not set, the latest DigestType is used, currently p1.
+  DigestType digest_type = 6 [(buf.validate.field).enum.defined_only = true];
   // Only return Commits with an id that contains this string using a case-insensitive comparison.
   string id_query = 5 [(buf.validate.field).string.max_len = 36];
 }

--- a/buf/registry/policy/v1beta1/commit_service.proto
+++ b/buf/registry/policy/v1beta1/commit_service.proto
@@ -55,7 +55,7 @@ message GetCommitsRequest {
   // If this DigestType is not available, an error is returned.
   // Note that certain DigestTypes may be deprecated over time.
   //
-  // If not set, the latest DigestType is used, currently P1.
+  // If not set, the latest DigestType is used, currently O1.
   DigestType digest_type = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
@@ -104,7 +104,7 @@ message ListCommitsRequest {
   // If this DigestType is not available, an error is returned.
   // Note that certain DigestTypes may be deprecated over time.
   //
-  // If not set, the latest DigestType is used, currently p1.
+  // If not set, the latest DigestType is used, currently O1.
   DigestType digest_type = 6 [(buf.validate.field).enum.defined_only = true];
   // Only return Commits with an id that contains this string using a case-insensitive comparison.
   string id_query = 5 [(buf.validate.field).string.max_len = 36];

--- a/buf/registry/policy/v1beta1/digest.proto
+++ b/buf/registry/policy/v1beta1/digest.proto
@@ -36,6 +36,6 @@ message Digest {
 // The type of Digest.
 enum DigestType {
   DIGEST_TYPE_UNSPECIFIED = 0;
-  // The p1 digest function.
-  DIGEST_TYPE_P1 = 1;
+  // The O1 digest function.
+  DIGEST_TYPE_O1 = 1;
 }

--- a/buf/registry/policy/v1beta1/digest.proto
+++ b/buf/registry/policy/v1beta1/digest.proto
@@ -1,0 +1,41 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// A digest of a Commit's content.
+//
+// A digest represents all content for a single Commit.
+message Digest {
+  // The type of the Digest.
+  DigestType type = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+  // The value of the Digest.
+  bytes value = 2 [(buf.validate.field).required = true];
+}
+
+// The type of Digest.
+enum DigestType {
+  DIGEST_TYPE_UNSPECIFIED = 0;
+  // The p1 digest function.
+  DIGEST_TYPE_P1 = 1;
+}

--- a/buf/registry/policy/v1beta1/label_service.proto
+++ b/buf/registry/policy/v1beta1/label_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package buf.registry.policy.v1beta1;
 
 import "buf/registry/policy/v1beta1/commit.proto";
+import "buf/registry/policy/v1beta1/digest.proto";
 import "buf/registry/policy/v1beta1/label.proto";
 import "buf/registry/policy/v1beta1/resource.proto";
 import "buf/validate/validate.proto";
@@ -29,7 +30,7 @@ service LabelService {
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
-  // List Labels for a given Policy or Commit.
+  // List Labels for a given Policy, Commit or Label.
   rpc ListLabels(ListLabelsRequest) returns (ListLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
@@ -167,6 +168,10 @@ message ListLabelHistoryRequest {
   //
   // If not specified, defaults to ORDER_DESC.
   Order order = 4 [(buf.validate.field).enum.defined_only = true];
+  // The DigestType to use for Digests returned on Commits.
+  // If this DigestType is not available, an error is returned. Note that certain DigestTypes may be
+  // If not set, the latest DigestType is used, currently P1.
+  DigestType digest_type = 6 [(buf.validate.field).enum.defined_only = true];
   // The Commit id to start from.
   //
   // It is an error to provide a Commit id that doesn't exist on the Label.

--- a/buf/registry/policy/v1beta1/label_service.proto
+++ b/buf/registry/policy/v1beta1/label_service.proto
@@ -170,7 +170,7 @@ message ListLabelHistoryRequest {
   Order order = 4 [(buf.validate.field).enum.defined_only = true];
   // The DigestType to use for Digests returned on Commits.
   // If this DigestType is not available, an error is returned. Note that certain DigestTypes may be
-  // If not set, the latest DigestType is used, currently P1.
+  // If not set, the latest DigestType is used, currently O1.
   DigestType digest_type = 6 [(buf.validate.field).enum.defined_only = true];
   // The Commit id to start from.
   //


### PR DESCRIPTION
This adds digest support to policies, following on from modules and plugins. The digest type for policies is O1.