### PR TITLE
Set typed Policy configuration

### DIFF
--- a/buf/registry/policy/v1beta1/configuration.proto
+++ b/buf/registry/policy/v1beta1/configuration.proto
@@ -1,0 +1,128 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.policy.v1beta1;
+
+import "buf/plugin/option/v1/option.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
+
+// PolicyConfig is the Policy's configuration. This consists of the built-in rules version and lint,
+// breaking, and plugin configurations required to run the Policy.
+message PolicyConfig {
+  // A check config represents the shared configurations for checks (e.g. lint and breaking).
+  message CheckConfig {
+    // The list of check rules and/or categories used for the Policy.
+    repeated string use = 1 [
+      (buf.validate.field).repeated.items = {
+        string: {
+          min_len: 3
+          max_len: 64
+          pattern: "^[A-Z0-9][A-Z0-9_]*[A-Z0-9]$"
+        }
+      },
+      (buf.validate.field).repeated.max_items = 250
+    ];
+    // The list of check rules and/or categories to exclude for the Policy.
+    repeated string except = 2 [
+      (buf.validate.field).repeated.items = {
+        string: {
+          min_len: 3
+          max_len: 64
+          pattern: "^[A-Z0-9][A-Z0-9_]*[A-Z0-9]$"
+        }
+      },
+      (buf.validate.field).repeated.max_items = 250
+    ];
+  }
+  // A lint config consists of the generic check config and additional lint-specifc configs
+  // required for running lint.
+  message LintConfig {
+    // The check config.
+    CheckConfig check_config = 1;
+    // The suffix that controls the behavior of the ENUM_ZERO_VALUE_SUFFIX lint rule. By default,
+    // this rule verifies that the zero value of all enums ends in `_UNSPECIFIED`, however, this
+    // allows organizations to choose a different suffix.
+    string enum_zero_value_suffix = 2 [(buf.validate.field).string.max_len = 250];
+    // The bool allows the same message type to be used for a single RPC's request and response type.
+    bool rpc_allow_same_request_response = 3;
+    // The bool allows RPC requests to be google.protobuf.Empty messages.
+    bool rpc_allow_google_protobuf_empty_requests = 4;
+    // The bool allows RPC responses to be google.protobuf.Empty messages.
+    bool rpc_allow_google_protobuf_empty_responses = 5;
+    // The suffix controls the behavior of the SERVICE_SUFFIX lint rule. By default, this rule
+    // verifies that all service names are suffixed with `Service`, however this allows organizations
+    // to choose a different suffix.
+    string service_suffix = 6 [(buf.validate.field).string.max_len = 250];
+  }
+  // A breaking config consists of the generic check config and additional breaking-specifc configs
+  // required for running breaking change detection.
+  message BreakingConfig {
+    // The check config.
+    CheckConfig check_config = 1;
+    // This bool determines whether to ignore unstable packages for breaking change detection:
+    //   - v\d+test.*
+    //   - v\d+(alpha|beta)\d*
+    //   - v\d+p\d+(alpha|beta)\d*
+    bool ignore_unstable_packages = 2;
+  }
+  // A plugin config consists of the configs for invoking a check plugin.
+  message CheckPluginConfig {
+    // The fully-qualified name of a check Plugin within a BSR instance.
+    //
+    // If an untyped reference is specified it is interpreted to either be an id or Label name. If
+    // an id, backends can choose to validate that the owner and plugin fields match this Name. If
+    // no reference is set, then at the time of running the Policy, the latest commit on the default
+    // label of the Plugin is used.
+    //
+    // A Name uniquely identifies a Plugin.
+    message Name {
+      // The name of the Organization owner.
+      string owner = 1 [
+        (buf.validate.field).required = true,
+        (buf.validate.field).string.max_len = 32
+      ];
+      // The name of the Plugin.
+      string plugin = 2 [(buf.validate.field).string = {
+        min_len: 2
+        max_len: 100
+      }];
+      // The untyped reference, applying the semantics as documented on the Name message.
+      //
+      // If this value is present but empty, this should be treated as not present, that is an empty
+      // value is the same as a null value.
+      string ref = 3 [(buf.validate.field).string.max_len = 250];
+    }
+    // The Plugin name.
+    Name name = 1 [(buf.validate.field).required = true];
+    // The Options for the Plugin.
+    repeated buf.plugin.option.v1.Option options = 3;
+    // The arguments to invoke the Plugin with.
+    repeated string args = 4 [
+      (buf.validate.field).repeated.max_items = 250,
+      (buf.validate.field).repeated.items = {
+        string: {max_len: 250}
+      }
+    ];
+  }
+  // The lint config.
+  LintConfig lint = 1;
+  // The breaking config.
+  BreakingConfig breaking = 2;
+  // The check plugin configs.
+  repeated CheckPluginConfig plugins = 3;
+}

--- a/buf/registry/policy/v1beta1/download_service.proto
+++ b/buf/registry/policy/v1beta1/download_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package buf.registry.policy.v1beta1;
 
 import "buf/registry/policy/v1beta1/commit.proto";
+import "buf/registry/policy/v1beta1/configuration.proto";
 import "buf/registry/policy/v1beta1/resource.proto";
 import "buf/validate/validate.proto";
 
@@ -58,8 +59,8 @@ message DownloadResponse {
   message Content {
     // The Commit associated with the Content.
     Commit commit = 1 [(buf.validate.field).required = true];
-    // The content.
-    bytes content = 2 [(buf.validate.field).required = true];
+    // The Policy config.
+    PolicyConfig config = 2 [(buf.validate.field).required = true];
   }
 
   // The contents for each reference in the same order as given on the request.

--- a/buf/registry/policy/v1beta1/upload_service.proto
+++ b/buf/registry/policy/v1beta1/upload_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package buf.registry.policy.v1beta1;
 
 import "buf/registry/policy/v1beta1/commit.proto";
+import "buf/registry/policy/v1beta1/configuration.proto";
 import "buf/registry/policy/v1beta1/label.proto";
 import "buf/registry/policy/v1beta1/policy.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
@@ -39,8 +40,8 @@ message UploadRequest {
   message Content {
     // The Policy of the reference.
     PolicyRef policy_ref = 1 [(buf.validate.field).required = true];
-    // The content to upload.
-    bytes content = 2 [(buf.validate.field).required = true];
+    // The Policy config to upload.
+    PolicyConfig config = 2 [(buf.validate.field).required = true];
     // The labels to associate with the Commit for the Content.
     //
     // If an id is set, this id must represent a Label that already exists and is owned by the


### PR DESCRIPTION
This PR sets the Policy configuration to a defined message type, `PolicyConfig`. This is used on uploading and downloading policies. A `PolicyConfig` represents the subset of the policy.yaml file that affects how a Policy is run. This fixes the calculation of the digest to the contents of the `PolicyConfig`. A digest is no longer affected by changes to the `buf.yaml` that don't alter the configuration, for example comments and policy name have no change in `PolicyConfig`.