### PR TITLE
Use `uri_or_empty` CEL rule for optional URIs

### DIFF
--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -165,9 +165,12 @@ message UpdateModulesRequest {
     optional string description = 5 [(buf.validate.field).string.max_len = 350];
     // The configurable URL in the description of the module.
     optional string url = 6 [
-      (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      (buf.validate.field).cel = {
+        id: "uri_or_empty"
+        expression: "this == '' || this.isUri()"
+        message: "value must be a valid URI"
+      },
+      (buf.validate.field).string.max_len = 255
     ];
     // The name of the default Label of the Module.
     //

--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -166,7 +166,8 @@ message UpdateModulesRequest {
     // The configurable URL in the description of the module.
     optional string url = 6 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
     // The name of the default Label of the Module.
     //

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -165,9 +165,12 @@ message UpdateModulesRequest {
     optional string description = 5 [(buf.validate.field).string.max_len = 350];
     // The configurable URL in the description of the module.
     optional string url = 6 [
-      (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      (buf.validate.field).cel = {
+        id: "uri_or_empty"
+        expression: "this == '' || this.isUri()"
+        message: "value must be a valid URI"
+      },
+      (buf.validate.field).string.max_len = 255
     ];
     // The name of the default Label of the Module.
     //

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -166,7 +166,8 @@ message UpdateModulesRequest {
     // The configurable URL in the description of the module.
     optional string url = 6 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
     // The name of the default Label of the Module.
     //

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -147,7 +147,8 @@ message UpdateOrganizationsRequest {
     // The configurable URL that represents the homepage for an Organization.
     optional string url = 3 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
     // The verification status of the Organization.
     optional OrganizationVerificationStatus verification_status = 4 [

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -146,9 +146,12 @@ message UpdateOrganizationsRequest {
     optional string description = 2 [(buf.validate.field).string.max_len = 350];
     // The configurable URL that represents the homepage for an Organization.
     optional string url = 3 [
-      (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      (buf.validate.field).cel = {
+        id: "uri_or_empty"
+        expression: "this == '' || this.isUri()"
+        message: "value must be a valid URI"
+      },
+      (buf.validate.field).string.max_len = 255
     ];
     // The verification status of the Organization.
     optional OrganizationVerificationStatus verification_status = 4 [

--- a/buf/registry/plugin/v1beta1/plugin_service.proto
+++ b/buf/registry/plugin/v1beta1/plugin_service.proto
@@ -168,7 +168,8 @@ message UpdatePluginsRequest {
     // The configurable source URL in the description of the Plugin.
     optional string source_url = 5 [
       (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255
+      (buf.validate.field).string.max_len = 255,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
   }
   // The Plugins to update.

--- a/buf/registry/plugin/v1beta1/plugin_service.proto
+++ b/buf/registry/plugin/v1beta1/plugin_service.proto
@@ -167,9 +167,12 @@ message UpdatePluginsRequest {
     optional string description = 4 [(buf.validate.field).string.max_len = 350];
     // The configurable source URL in the description of the Plugin.
     optional string source_url = 5 [
-      (buf.validate.field).string.uri = true,
-      (buf.validate.field).string.max_len = 255,
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      (buf.validate.field).cel = {
+        id: "uri_or_empty"
+        expression: "this == '' || this.isUri()"
+        message: "value must be a valid URI"
+      },
+      (buf.validate.field).string.max_len = 255
     ];
   }
   // The Plugins to update.


### PR DESCRIPTION
Fix for [this comment](https://github.com/bufbuild/registry-proto/pull/149#discussion_r2216655935), which still validates URI validity.