### PR TITLE
Plugin and Policy: Remove comments associated to review flow

### DIFF
--- a/buf/registry/plugin/v1beta1/label.proto
+++ b/buf/registry/plugin/v1beta1/label.proto
@@ -60,9 +60,7 @@ message Label {
   ];
   // The id of the Commit currently associated with the Label.
   //
-  // If policy checks are enabled, this will point to the most recent Commit that passed or was
-  // approved. To get the history of the Commits that have been associated with a Label, use
-  // ListLabelHistory.
+  // To get the history of the Commits that have been associated with a Label, use ListLabelHistory.
   string commit_id = 8 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.tuuid = true

--- a/buf/registry/plugin/v1beta1/label_service.proto
+++ b/buf/registry/plugin/v1beta1/label_service.proto
@@ -116,9 +116,7 @@ message ListLabelsRequest {
   // filters in the request):
   //   - If a Plugin is referenced, all Labels for the Plugin are returned.
   //   - If a Label is referenced, this Label is returned.
-  //   - If a Commit is referenced, all Labels that currently point to the Commit are returned. Note
-  //     that Labels only point to passed or approved Commits, or Commits where policy checks were
-  //     disabled.
+  //   - If a Commit is referenced, all Labels that currently point to the Commit are returned.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
   // The order to return the Labels.
   //

--- a/buf/registry/policy/v1beta1/label_service.proto
+++ b/buf/registry/policy/v1beta1/label_service.proto
@@ -116,9 +116,7 @@ message ListLabelsRequest {
   // filters in the request):
   //   - If a Policy is referenced, all Labels for the Policy are returned.
   //   - If a Label is referenced, this Label is returned.
-  //   - If a Commit is referenced, all Labels that currently point to the Commit are returned. Note
-  //     that Labels only point to passed or approved Commits, or Commits where policy checks were
-  //     disabled.
+  //   - If a Commit is referenced, all Labels that currently point to the Commit are returned.
   ResourceRef resource_ref = 3 [(buf.validate.field).required = true];
   // The order to return the Labels.
   //


### PR DESCRIPTION
Plugin and Policy labels are not protected via review flow, and these commits don't have review state. Only Module commits and labels have review flow.