### PR TITLE
Add disable_builtin field to policy configuration

### DIFF
--- a/buf/registry/policy/v1beta1/configuration.proto
+++ b/buf/registry/policy/v1beta1/configuration.proto
@@ -63,6 +63,8 @@ message PolicyConfig {
     // verifies that all service names are suffixed with `Service`, however this allows organizations
     // to choose a different suffix.
     string service_suffix = 7 [(buf.validate.field).string.max_len = 250];
+    // The bool disables the builtin rules and categories.
+    bool disable_builtin = 8;
   }
   // A breaking config consists of the generic check config and additional breaking-specifc configs
   // required for running breaking change detection.
@@ -94,6 +96,8 @@ message PolicyConfig {
     //   - v\d+(alpha|beta)\d*
     //   - v\d+p\d+(alpha|beta)\d*
     bool ignore_unstable_packages = 3;
+    // The bool disables the builtin rules and categories.
+    bool disable_builtin = 4;
   }
   // A plugin config consists of the configs for invoking a check plugin.
   message CheckPluginConfig {


### PR DESCRIPTION
This adds the bool field `disable_builtin` to lint and breaking policy configuration. When set no builtin rules or categories are evaluated. This is required for use with policies to disable the default rule or categories being evaluated when not intended. For example, to set only breaking rules the lint configuration would be set to disable builtin to ensure the defaults (STANDARD) aren't invoked.