### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,6 @@ jobs:
           fetch-depth: 1
       - name: install
         uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.x
-          cache-dependency-path: Makefile
       - name: make
         run: make
       - name: make checkgenerate


### PR DESCRIPTION
Noticed CI is failing because the latest version of Buf requires Go 1.24 and we don't pin a version. Remove the version pin.

Also removes cache-dependency-path, because the Makefile doesn't have version information that would result in the cache being busted.