### PR TITLE
Remove outdated comments on DownloadResponse.Content

### DIFF
--- a/buf/registry/module/v1/download_service.proto
+++ b/buf/registry/module/v1/download_service.proto
@@ -97,10 +97,6 @@ message DownloadResponse {
   // Content for a single Commit.
   message Content {
     // The Commit associated with the Content.
-    //
-    // The Commit associated with this ID will be present in the commits field.
-    //
-    // The Commit will use the DigestType specified in the request value.
     Commit commit = 1 [(buf.validate.field).required = true];
     // The Files of the content.
     //

--- a/buf/registry/module/v1beta1/download_service.proto
+++ b/buf/registry/module/v1beta1/download_service.proto
@@ -106,8 +106,6 @@ message DownloadResponse {
   message Content {
     // The Commit associated with the Content.
     //
-    // The Commit associated with this ID will be present in the commits field.
-    //
     // The Commit will use the DigestType specified in the request value.
     Commit commit = 1 [(buf.validate.field).required = true];
     // The Files of the content.


### PR DESCRIPTION
* Neither request or response has a `commits` field
* v1 does not have a DigestType in the request