### PR TITLE
Add GetCurrentUser to v1 UserService

### DIFF
--- a/buf/registry/owner/v1/user_service.proto
+++ b/buf/registry/owner/v1/user_service.proto
@@ -28,6 +28,10 @@ service UserService {
   rpc GetUsers(GetUsersRequest) returns (GetUsersResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // Get the currently authenticated User.
+  rpc GetCurrentUser(GetCurrentUserRequest) returns (GetCurrentUserResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   // List Users, usually by Organization.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
@@ -66,6 +70,13 @@ message GetUsersRequest {
 message GetUsersResponse {
   // The retrieved Users in the same order as requested.
   repeated User users = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message GetCurrentUserRequest {}
+
+message GetCurrentUserResponse {
+  // The currently authenticated User.
+  User user = 1 [(buf.validate.field).required = true];
 }
 
 message ListUsersRequest {


### PR DESCRIPTION
Retrieves the currently authenticated user.

I haven't documented error codes as we tend not to do that, but an implementation might respond with:

* Unauthenticated if the request does not include authentication
* NotFound if authentication is included, but does not match to a user
* InvalidArgument if the authentication is invalid
* PermissionDenied if the user has been disabled or deactivated for some reason

For context, here's how v1alpha1 defines a similar RPC: https://github.com/bufbuild/buf/blob/7471eb6817e604885bd7632cd8472de8940bec48/proto/buf/alpha/registry/v1alpha1/authn.proto#L23-L28