### PR TITLE
Fix: address style consistency issues

### DIFF
--- a/buf/registry/owner/v1/user.proto
+++ b/buf/registry/owner/v1/user.proto
@@ -71,10 +71,12 @@ message User {
   ];
 }
 
-// The state of the a User, either active or inactive.
+// The state of a User.
 enum UserState {
   USER_STATE_UNSPECIFIED = 0;
+  // The User is active.
   USER_STATE_ACTIVE = 1;
+  // The User is inactive.
   USER_STATE_INACTIVE = 2;
 }
 

--- a/buf/registry/plugin/v1beta1/collection_service.proto
+++ b/buf/registry/plugin/v1beta1/collection_service.proto
@@ -95,9 +95,12 @@ message GetPluginCollectionAssociationsResponse {
   // The Associations for the requested Plugins.
   message Association {
     // The id of the Plugin.
-    string plugin_id = 1;
-    // The collection ids associated with the Plugin.
-    repeated string collection_ids = 2;
+    string plugin_id = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.tuuid = true
+    ];
+    // The Collection ids associated with the Plugin.
+    repeated string collection_ids = 2 [(buf.validate.field).repeated.items.string.tuuid = true];
   }
   // The Associations for the requested Plugins in the same order as requested.
   repeated Association associations = 1;

--- a/buf/registry/policy/v1beta1/policy_service.proto
+++ b/buf/registry/policy/v1beta1/policy_service.proto
@@ -157,6 +157,7 @@ message UpdatePoliciesRequest {
       (buf.validate.field).enum.defined_only = true,
       (buf.validate.field).enum.not_in = 0
     ];
+    reserved 3;
     // The deprecation status of the Policy.
     optional PolicyState state = 4 [
       (buf.validate.field).enum.defined_only = true,


### PR DESCRIPTION
## Summary

- Add `required` and `tuuid` validation to `Association.plugin_id`
- Add `tuuid` validation to `Association.collection_ids` items
- Add comments to `UserState` enum values
- Fix typo in `UserState` enum comment ("of the a User" → "of a User")
- Reserve field 3 in `UpdatePoliciesRequest.Value`

---

Generated with an experimental Claude skill. I had it capture the style of this repo first, before apply it back on itself to check for consistency. 