### PR TITLE
Add update time ordering to ListModulesRequest

### DIFF
--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -75,6 +75,10 @@ message ListModulesRequest {
     ORDER_CREATE_TIME_DESC = 1;
     // Order by create_time oldest to newest.
     ORDER_CREATE_TIME_ASC = 2;
+    // Order by update_time newest to oldest.
+    ORDER_UPDATE_TIME_DESC = 3;
+    // Order by update_time oldest to newest.
+    ORDER_UPDATE_TIME_ASC = 4;
   }
   // The maximum number of items to return.
   //


### PR DESCRIPTION
The BSR frontend has a use-case for ordering modules by update time. I know we've been hesitant in the past to add specific conveniences for the BSR (and this may open the floodgates for other such orderings), but this ordering is easy to implement and generally useful for other clients without needing to consume the entire paginated stream.