### PR TITLE
Update comments pertaining to default label archiving

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
+          # Must be able to run the latest version of `buf`.
+          go-version: '1.26'
           # Check for latest Go version to run latest Buf version.
           check-latest: true
           # No caching needed; no Go files.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          # Must be able to run the latest version of `buf`.
-          go-version: '1.26'
-          # Check for latest Go version to run latest Buf version.
-          check-latest: true
+          # Must be able to run the latest version of `buf`, which updates
+          # every once in a while.
+          go-version: 'stable'
           # No caching needed; no Go files.
           cache: false
       - run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,13 +5,12 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          fetch-depth: 1
-      - name: install
-        uses: actions/setup-go@v6
-      - name: make
-        run: make
-      - name: make checkgenerate
-        run: make checkgenerate
+          # Check for latest Go version to run latest Buf version.
+          check-latest: true
+          # No caching needed; no Go files.
+          cache: false
+      - run: make
+      - run: make checkgenerate

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
 
 COPYRIGHT_YEARS := 2023-2025
+LICENSE_IGNORE := --ignore '\.yaml$$' --ignore '\.yml$$'
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -45,7 +46,8 @@ generate: $(BIN)/buf $(BIN)/license-header ## Format and regenerate license head
 	license-header \
 		--license-type apache \
 		--copyright-holder "Buf Technologies, Inc." \
-		--year-range "$(COPYRIGHT_YEARS)"
+		--year-range "$(COPYRIGHT_YEARS)" \
+		$(LICENSE_IGNORE)
 	buf format -w
 
 .PHONY: checkgenerate

--- a/buf/registry/module/v1/label_service.proto
+++ b/buf/registry/module/v1/label_service.proto
@@ -51,6 +51,8 @@ service LabelService {
   // Archive existing Labels.
   //
   // This operation is atomic. Either all Labels are archived or an error is returned.
+  //
+  // It is an error to archive the default Label.
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
   }

--- a/buf/registry/module/v1/module.proto
+++ b/buf/registry/module/v1/module.proto
@@ -70,8 +70,6 @@ message Module {
   // This Label may not yet exist. When a Module is created, it has no Commits, and Labels
   // must have a Commit, so this Label is not created when a Module is created. Additionally,
   // a User may modify the name of the default Label without this Label yet being created.
-  //
-  // This could also be the name of an archived Label.
   string default_label_name = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250

--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -134,8 +134,6 @@ message CreateModulesRequest {
     // The name of the default Label of the Module.
     //
     // If not set, the default Label will be named "main" upon creation.
-    //
-    // This may point to an archived Label.
     string default_label_name = 6 [(buf.validate.field).string.max_len = 250];
   }
   // The Modules to create.
@@ -177,8 +175,6 @@ message UpdateModulesRequest {
       (buf.validate.field).string.max_len = 255
     ];
     // The name of the default Label of the Module.
-    //
-    // This Label may not yet exist.
     //
     // This may not point to an archived Label.
     optional string default_label_name = 7 [

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -52,6 +52,8 @@ service LabelService {
   // Archive existing Labels.
   //
   // This operation is atomic. Either all Labels are archived or an error is returned.
+  //
+  // It is an error to archive the default Label.
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
   }

--- a/buf/registry/module/v1beta1/module.proto
+++ b/buf/registry/module/v1beta1/module.proto
@@ -70,8 +70,6 @@ message Module {
   // This Label may not yet exist. When a Module is created, it has no Commits, and Labels
   // must have a Commit, so this Label is not created when a Module is created. Additionally,
   // a User may modify the name of the default Label without this Label yet being created.
-  //
-  // This could also be the name of an archived Label.
   string default_label_name = 10 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.max_len = 250

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -130,8 +130,6 @@ message CreateModulesRequest {
     // The name of the default Label of the Module.
     //
     // If not set, the default Label will be named "main" upon creation.
-    //
-    // This may point to an archived Label.
     string default_label_name = 6 [(buf.validate.field).string.max_len = 250];
   }
   // The Modules to create.
@@ -173,8 +171,6 @@ message UpdateModulesRequest {
       (buf.validate.field).string.max_len = 255
     ];
     // The name of the default Label of the Module.
-    //
-    // This Label may not yet exist.
     //
     // This may not point to an archived Label.
     optional string default_label_name = 7 [

--- a/buf/registry/plugin/v1beta1/label_service.proto
+++ b/buf/registry/plugin/v1beta1/label_service.proto
@@ -51,6 +51,8 @@ service LabelService {
   // Archive existing Labels.
   //
   // This operation is atomic. Either all Labels are archived or an error is returned.
+  //
+  // It is an error to archive the default Label.
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
   }

--- a/buf/registry/policy/v1beta1/label_service.proto
+++ b/buf/registry/policy/v1beta1/label_service.proto
@@ -51,6 +51,8 @@ service LabelService {
   // Archive existing Labels.
   //
   // This operation is atomic. Either all Labels are archived or an error is returned.
+  //
+  // It is an error to archive the default Label.
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
   }


### PR DESCRIPTION
I think these are just out of date - we don't allow archiving a default label.

Also fixes CI, because the runner installed version of Go (1.24) doesn't support running the latest version of `buf` (requires 1.25).