### PR TITLE
Relax owner name validation to allow single-character names

### DIFF
--- a/buf/registry/owner/v1/organization.proto
+++ b/buf/registry/owner/v1/organization.proto
@@ -42,9 +42,9 @@ message Organization {
   // A name uniquely identifies an Organization, however name is mutable.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.min_len = 2,
+    (buf.validate.field).string.min_len = 1,
     (buf.validate.field).string.max_len = 32,
-    (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
+    (buf.validate.field).string.pattern = "^[a-z]([a-z0-9-]*[a-z0-9])?$"
   ];
   // The configurable description of the Organization.
   string description = 5 [(buf.validate.field).string.max_len = 350];
@@ -84,9 +84,9 @@ message OrganizationRef {
     string id = 1 [(buf.validate.field).string.tuuid = true];
     // The name of the Organization.
     string name = 2 [(buf.validate.field).string = {
-      min_len: 2
+      min_len: 1
       max_len: 32
-      pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+      pattern: "^[a-z]([a-z0-9-]*[a-z0-9])?$"
     }];
   }
 }

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -108,9 +108,9 @@ message CreateOrganizationsRequest {
     // The name of the Organization.
     string name = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.min_len = 2,
+      (buf.validate.field).string.min_len = 1,
       (buf.validate.field).string.max_len = 32,
-      (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
+      (buf.validate.field).string.pattern = "^[a-z]([a-z0-9-]*[a-z0-9])?$"
     ];
     // The configurable description of the Organization.
     string description = 2 [(buf.validate.field).string.max_len = 350];

--- a/buf/registry/owner/v1/owner.proto
+++ b/buf/registry/owner/v1/owner.proto
@@ -48,9 +48,9 @@ message OwnerRef {
     string id = 1 [(buf.validate.field).string.tuuid = true];
     // The name of the User or Organization.
     string name = 2 [(buf.validate.field).string = {
-      min_len: 2
+      min_len: 1
       max_len: 32
-      pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+      pattern: "^[a-z]([a-z0-9-]*[a-z0-9])?$"
     }];
   }
 }

--- a/buf/registry/owner/v1/user.proto
+++ b/buf/registry/owner/v1/user.proto
@@ -42,9 +42,9 @@ message User {
   // A name uniquely identifies a User, however name is mutable.
   string name = 4 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.min_len = 2,
+    (buf.validate.field).string.min_len = 1,
     (buf.validate.field).string.max_len = 32,
-    (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
+    (buf.validate.field).string.pattern = "^[a-z]([a-z0-9-]*[a-z0-9])?$"
   ];
   // The type of the User.
   UserType type = 5 [
@@ -114,9 +114,9 @@ message UserRef {
     string id = 1 [(buf.validate.field).string.tuuid = true];
     // The name of the User.
     string name = 2 [(buf.validate.field).string = {
-      min_len: 2
+      min_len: 1
       max_len: 32
-      pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+      pattern: "^[a-z]([a-z0-9-]*[a-z0-9])?$"
     }];
   }
 }

--- a/buf/registry/owner/v1/user_service.proto
+++ b/buf/registry/owner/v1/user_service.proto
@@ -134,9 +134,9 @@ message CreateUsersRequest {
     // The name of the User.
     string name = 1 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.min_len = 2,
+      (buf.validate.field).string.min_len = 1,
       (buf.validate.field).string.max_len = 32,
-      (buf.validate.field).string.pattern = "^[a-z][a-z0-9-]*[a-z0-9]$"
+      (buf.validate.field).string.pattern = "^[a-z]([a-z0-9-]*[a-z0-9])?$"
     ];
     // The type of the User.
     //


### PR DESCRIPTION
Reduces `min_len` from 2 to 1 and updates the regex from `^[a-z][a-z0-9-]*[a-z0-9]$` to `^[a-z]([a-z0-9-]*[a-z0-9])?$` for all `name` fields in `buf/registry/owner/v1` (User, UserRef, Organization, OrganizationRef, OwnerRef, and the Create RPC values).

Both the length and the regex previously required a minimum of 2 characters; the new regex preserves the no-trailing-hyphen rule while letting a single `[a-z]` validate.

Note: applications implementing these APIs might apply stricter naming rules.