### PR TITLE
Add visibility fields to organization create/update/get protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.tmp/
+.idea
+*.iml
+.DS_Store

--- a/buf/registry/owner/v1/organization.proto
+++ b/buf/registry/owner/v1/organization.proto
@@ -59,6 +59,9 @@ message Organization {
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
+  OrganizationVisibility visibility = 8 [
+    (buf.validate.field).enum.defined_only = true
+  ];
 }
 
 // The verification status of an Organization.
@@ -70,6 +73,15 @@ enum OrganizationVerificationStatus {
   ORGANIZATION_VERIFICATION_STATUS_VERIFIED = 2;
   // The Organization is an official organization of the BSR owner.
   ORGANIZATION_VERIFICATION_STATUS_OFFICIAL = 3;
+}
+
+// The visibility of an Organization, currently either public or private.
+enum OrganizationVisibility {
+  ORGANIZATION_VISIBILITY_UNSPECIFIED = 0;
+  // ORGANIZATION_VISIBILITY_PUBLIC says that the organization is publicly available.
+  ORGANIZATION_VISIBILITY_PUBLIC = 1;
+  // ORGANIZATION_VISIBILITY_PRIVATE says that the organization is private.
+  ORGANIZATION_VISIBILITY_PRIVATE = 2;
 }
 
 // OrganizationRef is a reference to an Organization, either an id or a name.

--- a/buf/registry/owner/v1/organization.proto
+++ b/buf/registry/owner/v1/organization.proto
@@ -59,9 +59,7 @@ message Organization {
     (buf.validate.field).required = true,
     (buf.validate.field).enum.defined_only = true
   ];
-  OrganizationVisibility visibility = 8 [
-    (buf.validate.field).enum.defined_only = true
-  ];
+  OrganizationVisibility visibility = 8 [(buf.validate.field).enum.defined_only = true];
 }
 
 // The verification status of an Organization.

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -124,6 +124,11 @@ message CreateOrganizationsRequest {
     //
     // If not set, the Organization will default to VERIFICATION_STATUS_UNVERIFIED.
     OrganizationVerificationStatus verification_status = 4 [(buf.validate.field).enum.defined_only = true];
+    // If not set, the Organization will default to ORGANIZATION_VISIBILITY_PUBLIC.
+    OrganizationVisibility visibility = 5 [
+      (buf.validate.field).enum.defined_only = true,
+      (buf.validate.field).enum.not_in = 0
+    ];
   }
   // The Organizations to create.
   repeated Value values = 1 [
@@ -155,6 +160,10 @@ message UpdateOrganizationsRequest {
     ];
     // The verification status of the Organization.
     optional OrganizationVerificationStatus verification_status = 4 [
+      (buf.validate.field).enum.defined_only = true,
+      (buf.validate.field).enum.not_in = 0
+    ];
+    OrganizationVisibility visibility = 5 [
       (buf.validate.field).enum.defined_only = true,
       (buf.validate.field).enum.not_in = 0
     ];

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -125,7 +125,7 @@ message CreateOrganizationsRequest {
     // If not set, the Organization will default to VERIFICATION_STATUS_UNVERIFIED.
     OrganizationVerificationStatus verification_status = 4 [(buf.validate.field).enum.defined_only = true];
     // If not set, the Organization will default to ORGANIZATION_VISIBILITY_PUBLIC.
-    OrganizationVisibility visibility = 5 [
+    optional OrganizationVisibility visibility = 5 [
       (buf.validate.field).enum.defined_only = true,
       (buf.validate.field).enum.not_in = 0
     ];

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -163,7 +163,7 @@ message UpdateOrganizationsRequest {
       (buf.validate.field).enum.defined_only = true,
       (buf.validate.field).enum.not_in = 0
     ];
-    OrganizationVisibility visibility = 5 [
+    optional OrganizationVisibility visibility = 5 [
       (buf.validate.field).enum.defined_only = true,
       (buf.validate.field).enum.not_in = 0
     ];


### PR DESCRIPTION
As a first step towards enabling private organizations, the protobuf definitions for CreateOrganizationsRequest.Value, UpdateOrganizationsRequest.Value, and Organization are updated to include a visibility field. A new enum OrganizationVisibility is also defined.