### PR TITLE
Add iam v1 token service

### DIFF
--- a/buf/registry/iam/v1/resource_type.proto
+++ b/buf/registry/iam/v1/resource_type.proto
@@ -1,0 +1,34 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.iam.v1;
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/iam/v1";
+
+// The type of a resource in the BSR.
+enum ResourceType {
+  RESOURCE_TYPE_UNSPECIFIED = 0;
+  // The resource is a User.
+  RESOURCE_TYPE_USER = 1;
+  // The resource is an Organization.
+  RESOURCE_TYPE_ORGANIZATION = 2;
+  // The resource is a Module.
+  RESOURCE_TYPE_MODULE = 3;
+  // The resource is a Plugin.
+  RESOURCE_TYPE_PLUGIN = 4;
+  // The resource is a Policy.
+  RESOURCE_TYPE_POLICY = 5;
+}

--- a/buf/registry/iam/v1/scope.proto
+++ b/buf/registry/iam/v1/scope.proto
@@ -1,0 +1,54 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.iam.v1;
+
+import "buf/registry/iam/v1/resource_type.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/iam/v1";
+
+// The scope that a restriction applies to.
+//
+// A Scope is either the entire instance or a single resource.
+message Scope {
+  // Instance scopes to the entire instance.
+  message Instance {}
+  // Resource scopes to a single resource.
+  //
+  // If the resource owns other resources (e.g. Organizations),
+  // those resources are also included in the scope.
+  message Resource {
+    // The id of the resource.
+    string resource_id = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.tuuid = true
+    ];
+    // The type of the resource that resource_id refers to.
+    ResourceType resource_type = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).enum.defined_only = true,
+      (buf.validate.field).enum.not_in = 0
+    ];
+  }
+  oneof value {
+    option (buf.validate.oneof).required = true;
+    // The Scope applies to all resources on the instance.
+    Instance instance = 1;
+    // The Scope applies to a single resource.
+    Resource resource = 2;
+  }
+}

--- a/buf/registry/iam/v1/token.proto
+++ b/buf/registry/iam/v1/token.proto
@@ -1,0 +1,130 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.iam.v1;
+
+import "buf/registry/iam/v1/scope.proto";
+import "buf/registry/owner/v1/user.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/registry/priv/validate/v1beta1/validate.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/iam/v1";
+
+// A Token on the BSR.
+//
+// A Token is a bearer credential that authenticates RPCs as its owning User. A Token may be
+// restricted to a subset of the User's permissions via ScopedPermissions.
+//
+// A Token's name and ScopedPermissions may be updated after creation. All other properties are
+// immutable.
+//
+// The secret value of a Token is returned only when the Token is created, via CreateTokensResponse.
+// It cannot be retrieved afterwards.
+message Token {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The id of the Token.
+  string id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The time the Token was created.
+  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  // The last time the Token was updated.
+  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  // The time the Token expires.
+  //
+  // If not set, the Token does not expire.
+  google.protobuf.Timestamp expire_time = 4;
+  // The name of the Token.
+  //
+  // Names are not guaranteed to be unique among the Tokens owned by a User.
+  string name = 5 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.min_len = 3,
+    (buf.validate.field).string.max_len = 256
+  ];
+  // The id of the User that owns the Token.
+  string user_id = 6 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The scoped permissions of the Token.
+  //
+  // If empty, the Token has no declared permission restrictions and its effective
+  // permissions are the user's permissions resolved at request time.
+  //
+  // Otherwise, the Token's effective permissions are the intersection of these
+  // declared permissions and the user's permissions resolved at request time.
+  //
+  // In other words, ScopedPermissions can restrict the permissions of a Token,
+  // but cannot add any permissions that the User does not already have.
+  repeated ScopedPermission scoped_permissions = 7 [
+    (buf.validate.field).repeated.max_items = 250,
+    (buf.validate.field).cel = {
+      id: "scoped_permissions.unique"
+      message: "scoped permissions must have unique scope and permission pairs"
+      expression: "this.map(sp, (has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id) + '|' + sp.permission).unique()"
+    }
+  ];
+}
+
+// A permission that applies within a specific Scope.
+//
+// ScopedPermissions restrict a Token to a subset of its owning User's permissions.
+message ScopedPermission {
+  // The Scope that the permission applies to.
+  Scope scope = 1 [(buf.validate.field).required = true];
+  // The permission allowed within the Scope (e.g. "bsr.module.delete").
+  string permission = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.(buf.registry.priv.validate.v1beta1.permission_name) = true
+  ];
+}
+
+// TokenRef is a reference to a Token, either an id or a name.
+//
+// This is used in requests.
+message TokenRef {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The name of a Token owned by a User.
+  //
+  // Token names are not guaranteed to be unique among the Tokens owned by a User. If the name
+  // matches more than one of the User's Tokens, an error is returned; reference the Token by id
+  // instead.
+  message Name {
+    // The reference to the user which owns the token.
+    // TODO(pkw): Should this default to the user calling the TokenService?
+    buf.registry.owner.v1.UserRef user_ref = 1;
+    // The name of the token.
+    string name = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.min_len = 3,
+      (buf.validate.field).string.max_len = 256
+    ];
+  }
+
+  oneof value {
+    option (buf.validate.oneof).required = true;
+    // The id of the Token.
+    string id = 1 [(buf.validate.field).string.tuuid = true];
+    // The name of the user's token.
+    Name name = 2;
+  }
+}

--- a/buf/registry/priv/validate/v1beta1/validate.proto
+++ b/buf/registry/priv/validate/v1beta1/validate.proto
@@ -1,0 +1,51 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package buf.registry.priv.validate.v1beta1;
+
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/priv/validate/v1beta1";
+
+extend buf.validate.StringRules {
+  // A validation rule for concrete Permission names.
+  //
+  // A Permission name is a dotted identifier of 2 to 255 characters. Each
+  // dot-separated component starts with a lowercase letter, contains lowercase
+  // letters, digits, and internal hyphens, and ends with a lowercase
+  // alphanumeric character. Components may not contain consecutive hyphens.
+  //
+  // For example, "bsr.module.delete".
+  //
+  // Use (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE for optional fields.
+  optional bool permission_name = 12001 [
+    (buf.validate.predefined).cel = {
+      id: "string.permission_name.len"
+      message: "permission name must be between 2 and 255 characters"
+      expression: "this == '' || (this.size() >= 2 && this.size() <= 255)"
+    },
+    (buf.validate.predefined).cel = {
+      id: "string.permission_name.pattern"
+      message: "permission name must be a dotted identifier where each component starts with a lowercase letter, contains lowercase letters, digits, and internal hyphens, and ends with a lowercase alphanumeric character (e.g. \"bsr.module.delete\")"
+      expression: "this == '' || this.matches('^[a-z][a-z0-9]*(-[a-z0-9]+)*([.][a-z][a-z0-9]*(-[a-z0-9]+)*)*$')"
+    },
+    (buf.validate.predefined).cel = {
+      id: "string.permission_name.empty"
+      message: "permission name must not be empty"
+      expression: "this != ''"
+    }
+  ];
+}


### PR DESCRIPTION
This adds `buf.registry.iam.v1.TokenService` and its dependencies (`ResourceType`, `Scope` and `permission` validation rule).