### PR TITLE
Pin buf CLI version for build reproducibility

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -15,3 +15,4 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
+          version: "1.70.0"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ BIN := .tmp/bin
 export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
 
+BUF_VERSION := v1.70.0
 COPYRIGHT_YEARS := 2023-2025
 LICENSE_IGNORE := --ignore '\.yaml$$' --ignore '\.yml$$'
 
@@ -57,8 +58,8 @@ checkgenerate:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	go install github.com/bufbuild/buf/cmd/buf@latest
+	go install github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
-	go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@latest
+	go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@$(BUF_VERSION)


### PR DESCRIPTION
The current makefile pulls down the latest version of the Buf CLI (`@latest`). Update it to define a specific version for build reproducibility.