### PR TITLE
Update v1 permissions

### DIFF
--- a/buf/registry/admin/v1/settings_service.proto
+++ b/buf/registry/admin/v1/settings_service.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package buf.registry.admin.v1;
 
 import "buf/registry/admin/v1/settings.proto";
-import "buf/registry/plugin/v1beta1/plugin.proto";
 import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/registry/resource/v1/resource_visibility_control.proto";
 import "buf/validate/validate.proto";

--- a/buf/registry/audit/v1/audit_service.proto
+++ b/buf/registry/audit/v1/audit_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package buf.registry.audit.v1;
 
 import "buf/registry/audit/v1/event.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "google/protobuf/timestamp.proto";
 
 // AuditService is the Audit service.
@@ -24,6 +25,7 @@ service AuditService {
   // ListEvents lists audited events recorded in the BSR instance.
   rpc ListEvents(ListEventsRequest) returns (ListEventsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.audit.list";
   }
 }
 

--- a/buf/registry/gensdk/v1/recommended_sdk_service.proto
+++ b/buf/registry/gensdk/v1/recommended_sdk_service.proto
@@ -31,18 +31,18 @@ service RecommendedSDKService {
   // same level.
   rpc AddRecommendedSDK(AddRecommendedSDKRequest) returns (AddRecommendedSDKResponse) {
     option idempotency_level = IDEMPOTENT;
-    // bsr.module-settings.update is required if the recommendation level is module
-    // bsr.organization-settings.update is required if the recommendation level is organization,
-    // bsr.instance-settings.update is required if the recommendation level is instance,
+    // bsr.module-settings.update is required if the recommendation level is a module
+    // bsr.organization-settings.update is required if the recommendation level is an organization,
+    // bsr.instance-settings.update is required if the recommendation level is the instance,
     // Additionally, bsr.plugin.get is required for any private plugins.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Remove an SDK from the list of recommended SDKs at a given level.
   rpc RemoveRecommendedSDK(RemoveRecommendedSDKRequest) returns (RemoveRecommendedSDKResponse) {
     option idempotency_level = IDEMPOTENT;
-    // bsr.module-settings.update is required if the recommendation level is module
-    // bsr.organization-settings.update is required if the recommendation level is organization,
-    // bsr.instance-settings.update is required if the recommendation level is instance,
+    // bsr.module-settings.update is required if the recommendation level is a module
+    // bsr.organization-settings.update is required if the recommendation level is an organization,
+    // bsr.instance-settings.update is required if the recommendation level is the instance,
     // Additionally, bsr.plugin.get is required for any private plugins.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
@@ -52,9 +52,9 @@ service RecommendedSDKService {
   // make a request per level to determine whether an SDK is recommended at a higher level.
   rpc ListRecommendedSDKs(ListRecommendedSDKsRequest) returns (ListRecommendedSDKsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // If the recommendation level is module, bsr.module.get is required.
-    // If the recommendation level is organization, bsr.organization.get is required.
-    // If the recommendation level is instance, no permission required.
+    // If the recommendation level is a private module, bsr.module.get is required.
+    // If the recommendation level is a private organization, bsr.organization.get is required.
+    // If the recommendation level is the instance, no permission required.
     // The result is filtered to the SDKs whose plugin the caller may read and has bsr.plugin.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }

--- a/buf/registry/gensdk/v1/recommended_sdk_service.proto
+++ b/buf/registry/gensdk/v1/recommended_sdk_service.proto
@@ -31,19 +31,19 @@ service RecommendedSDKService {
   // same level.
   rpc AddRecommendedSDK(AddRecommendedSDKRequest) returns (AddRecommendedSDKResponse) {
     option idempotency_level = IDEMPOTENT;
-    // bsr.module-settings.update is required if the recommendation level is a module
-    // bsr.organization-settings.update is required if the recommendation level is an organization,
-    // bsr.instance-settings.update is required if the recommendation level is the instance,
-    // Additionally, bsr.plugin.get is required for any private plugins.
+    // bsr.module-settings.update is required if the recommendation level is a Module.
+    // bsr.organization-settings.update is required if the recommendation level is an Organization.
+    // bsr.instance-settings.update is required if the recommendation level is the instance.
+    // Additionally, bsr.plugin.get is required for any private Plugin referenced.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Remove an SDK from the list of recommended SDKs at a given level.
   rpc RemoveRecommendedSDK(RemoveRecommendedSDKRequest) returns (RemoveRecommendedSDKResponse) {
     option idempotency_level = IDEMPOTENT;
-    // bsr.module-settings.update is required if the recommendation level is a module
-    // bsr.organization-settings.update is required if the recommendation level is an organization,
-    // bsr.instance-settings.update is required if the recommendation level is the instance,
-    // Additionally, bsr.plugin.get is required for any private plugins.
+    // bsr.module-settings.update is required if the recommendation level is a Module.
+    // bsr.organization-settings.update is required if the recommendation level is an Organization.
+    // bsr.instance-settings.update is required if the recommendation level is the instance.
+    // Additionally, bsr.plugin.get is required for any private Plugin referenced.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // List the recommended SDKs at a given level.
@@ -52,10 +52,11 @@ service RecommendedSDKService {
   // make a request per level to determine whether an SDK is recommended at a higher level.
   rpc ListRecommendedSDKs(ListRecommendedSDKsRequest) returns (ListRecommendedSDKsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // If the recommendation level is a private module, bsr.module.get is required.
-    // If the recommendation level is a private organization, bsr.organization.get is required.
-    // If the recommendation level is the instance, no permission required.
-    // The result is filtered to the SDKs whose plugin the caller may read and has bsr.plugin.get for.
+    // bsr.module.get is required if the recommendation level is a private Module.
+    // bsr.organization.get is required if the recommendation level is a private Organization.
+    // No Permission is required if the recommendation level is the instance.
+    // The response is filtered to the SDKs for public Plugins or private Plugins that the caller
+    // may read and has bsr.plugin.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
 }

--- a/buf/registry/gensdk/v1/recommended_sdk_service.proto
+++ b/buf/registry/gensdk/v1/recommended_sdk_service.proto
@@ -18,7 +18,7 @@ package buf.registry.gensdk.v1;
 
 import "buf/registry/gensdk/v1/recommended_sdk.proto";
 import "buf/registry/plugin/v1/plugin.proto";
-import "buf/registry/resource/v1/resource_visibility_control.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/gensdk/v1";
@@ -31,10 +31,20 @@ service RecommendedSDKService {
   // same level.
   rpc AddRecommendedSDK(AddRecommendedSDKRequest) returns (AddRecommendedSDKResponse) {
     option idempotency_level = IDEMPOTENT;
+    // bsr.module-settings.update is required if the recommendation level is module
+    // bsr.organization-settings.update is required if the recommendation level is organization,
+    // bsr.instance-settings.update is required if the recommendation level is instance,
+    // Additionally, bsr.plugin.get is required for any private plugins.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Remove an SDK from the list of recommended SDKs at a given level.
   rpc RemoveRecommendedSDK(RemoveRecommendedSDKRequest) returns (RemoveRecommendedSDKResponse) {
     option idempotency_level = IDEMPOTENT;
+    // bsr.module-settings.update is required if the recommendation level is module
+    // bsr.organization-settings.update is required if the recommendation level is organization,
+    // bsr.instance-settings.update is required if the recommendation level is instance,
+    // Additionally, bsr.plugin.get is required for any private plugins.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // List the recommended SDKs at a given level.
   //
@@ -42,6 +52,11 @@ service RecommendedSDKService {
   // make a request per level to determine whether an SDK is recommended at a higher level.
   rpc ListRecommendedSDKs(ListRecommendedSDKsRequest) returns (ListRecommendedSDKsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // If the recommendation level is module, bsr.module.get is required.
+    // If the recommendation level is organization, bsr.organization.get is required.
+    // If the recommendation level is instance, no permission required.
+    // The result is filtered to the SDKs whose plugin the caller may read and has bsr.plugin.get for.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
 }
 

--- a/buf/registry/iam/v1/permission.proto
+++ b/buf/registry/iam/v1/permission.proto
@@ -23,11 +23,7 @@ import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/iam/v1";
 
-// A Permission on the BSR.
-//
-// A Permission is an atomic capability that gates access to one or more RPCs. Permissions are
-// registered by the system and granted to Users, and may be further restricted on a Token via
-// ScopedPermissions.
+// A Permission on the BSR. It is used to restrict the capabilities of a Token via ScopedPermissions.
 //
 // A Permission is identified by its name; it does not have a separate id.
 message Permission {

--- a/buf/registry/iam/v1/permission.proto
+++ b/buf/registry/iam/v1/permission.proto
@@ -48,4 +48,13 @@ message Permission {
     (buf.validate.field).repeated.items.enum.defined_only = true,
     (buf.validate.field).repeated.items.enum.not_in = 0
   ];
+  // Other Permissions that this Permission includes.
+  //
+  // Binding this Permission at a scope also satisfies checks for every included
+  // Permission at that same scope, exactly as if the included Permissions were
+  // bound alongside it.
+  repeated string included_permissions = 4 [
+    (buf.validate.field).repeated.unique = true,
+    (buf.validate.field).repeated.items.string.(buf.registry.priv.validate.v1beta1.permission_name) = true
+  ];
 }

--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -33,7 +33,9 @@ service ModuleService {
   // List Modules, usually for a specific User or Organization.
   rpc ListModules(ListModulesRequest) returns (ListModulesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.list";
+    // bsr.organization.get is required for OwnerRefs resolving to private organizations.
+    // The response is filtered to the modules the caller may read and has bsr.module.get for.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Modules.
   //

--- a/buf/registry/module/v1/module_service.proto
+++ b/buf/registry/module/v1/module_service.proto
@@ -33,8 +33,9 @@ service ModuleService {
   // List Modules, usually for a specific User or Organization.
   rpc ListModules(ListModulesRequest) returns (ListModulesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // bsr.organization.get is required for OwnerRefs resolving to private organizations.
-    // The response is filtered to the modules the caller may read and has bsr.module.get for.
+    // bsr.organization.get is required for any OwnerRef that resolves to a private Organization.
+    // The response is filtered to public Modules and private Modules that the caller may read and
+    // has bsr.module.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Modules.

--- a/buf/registry/module/v1/resource_service.proto
+++ b/buf/registry/module/v1/resource_service.proto
@@ -27,11 +27,7 @@ service ResourceService {
   // Get Resources.
   rpc GetResources(GetResourcesRequest) returns (GetResourcesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // The Permission required for each ResourceRef depends on the type of the
-    // resource it references: a Module requires the bsr.module.get Permission,
-    // a Label requires the bsr.label.get Permission, and a Commit requires the
-    // bsr.commit.get Permission.
-    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
 }
 

--- a/buf/registry/module/v1beta1/commit_service.proto
+++ b/buf/registry/module/v1beta1/commit_service.proto
@@ -19,6 +19,7 @@ package buf.registry.module.v1beta1;
 import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/module/v1beta1/digest.proto";
 import "buf/registry/module/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -28,10 +29,12 @@ service CommitService {
   // Get Commits.
   rpc GetCommits(GetCommitsRequest) returns (GetCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
   // List Commits for a given Module, Label, or Commit.
   rpc ListCommits(ListCommitsRequest) returns (ListCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
 }
 

--- a/buf/registry/module/v1beta1/download_service.proto
+++ b/buf/registry/module/v1beta1/download_service.proto
@@ -20,6 +20,7 @@ import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/module/v1beta1/digest.proto";
 import "buf/registry/module/v1beta1/file.proto";
 import "buf/registry/module/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -31,6 +32,7 @@ service DownloadService {
   // Content consists of the .proto files, license files, and documentation files.
   rpc Download(DownloadRequest) returns (DownloadResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
 }
 

--- a/buf/registry/module/v1beta1/graph_service.proto
+++ b/buf/registry/module/v1beta1/graph_service.proto
@@ -19,6 +19,7 @@ package buf.registry.module.v1beta1;
 import "buf/registry/module/v1beta1/digest.proto";
 import "buf/registry/module/v1beta1/graph.proto";
 import "buf/registry/module/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -33,6 +34,7 @@ service GraphService {
   // A dependency graph is a directed acyclic graph.
   rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
 }
 

--- a/buf/registry/module/v1beta1/label_service.proto
+++ b/buf/registry/module/v1beta1/label_service.proto
@@ -20,6 +20,7 @@ import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/module/v1beta1/digest.proto";
 import "buf/registry/module/v1beta1/label.proto";
 import "buf/registry/module/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -29,14 +30,17 @@ service LabelService {
   // Get Labels by id or name.
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
   // List Labels for a given Module, Commit or Label.
   rpc ListLabels(ListLabelsRequest) returns (ListLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
   // List the history of a Label.
   rpc ListLabelHistory(ListLabelHistoryRequest) returns (ListLabelHistoryResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
   // Create or update Labels on a Module.
   //
@@ -48,6 +52,7 @@ service LabelService {
   // This operation is atomic. Either all Labels are created/updated or an error is returned.
   rpc CreateOrUpdateLabels(CreateOrUpdateLabelsRequest) returns (CreateOrUpdateLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.push";
   }
   // Archive existing Labels.
   //
@@ -56,12 +61,14 @@ service LabelService {
   // It is an error to archive the default Label.
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.push";
   }
   // Unarchive existing Labels.
   //
   // This operation is atomic. Either all Labels are unarchived or an error is returned.
   rpc UnarchiveLabels(UnarchiveLabelsRequest) returns (UnarchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.push";
   }
 }
 

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -18,6 +18,7 @@ package buf.registry.module.v1beta1;
 
 import "buf/registry/module/v1beta1/module.proto";
 import "buf/registry/owner/v1/owner.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -27,10 +28,14 @@ service ModuleService {
   // Get Modules by id or name.
   rpc GetModules(GetModulesRequest) returns (GetModulesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
   // List Modules, usually for a specific User or Organization.
   rpc ListModules(ListModulesRequest) returns (ListModulesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // bsr.organization.get is required for OwnerRefs resolving to private organizations.
+    // The response is filtered to the modules the caller may read and has bsr.module.get for.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Modules.
   //
@@ -39,18 +44,21 @@ service ModuleService {
   // This operation is atomic. Either all Modules are created or an error is returned.
   rpc CreateModules(CreateModulesRequest) returns (CreateModulesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.create";
   }
   // Update existing Modules.
   //
   // This operation is atomic. Either all Modules are updated or an error is returned.
   rpc UpdateModules(UpdateModulesRequest) returns (UpdateModulesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.update";
   }
   // Delete existing Modules.
   //
   // This operation is atomic. Either all Modules are deleted or an error is returned.
   rpc DeleteModules(DeleteModulesRequest) returns (DeleteModulesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.delete";
   }
 }
 

--- a/buf/registry/module/v1beta1/module_service.proto
+++ b/buf/registry/module/v1beta1/module_service.proto
@@ -33,8 +33,9 @@ service ModuleService {
   // List Modules, usually for a specific User or Organization.
   rpc ListModules(ListModulesRequest) returns (ListModulesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // bsr.organization.get is required for OwnerRefs resolving to private organizations.
-    // The response is filtered to the modules the caller may read and has bsr.module.get for.
+    // bsr.organization.get is required for any OwnerRef that resolves to a private Organization.
+    // The response is filtered to public Modules and private Modules that the caller may read and
+    // has bsr.module.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Modules.

--- a/buf/registry/module/v1beta1/resource_service.proto
+++ b/buf/registry/module/v1beta1/resource_service.proto
@@ -18,6 +18,7 @@ package buf.registry.module.v1beta1;
 
 import "buf/registry/module/v1beta1/digest.proto";
 import "buf/registry/module/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -27,6 +28,7 @@ service ResourceService {
   // Get Resources.
   rpc GetResources(GetResourcesRequest) returns (GetResourcesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.get";
   }
 }
 

--- a/buf/registry/module/v1beta1/upload_service.proto
+++ b/buf/registry/module/v1beta1/upload_service.proto
@@ -20,6 +20,7 @@ import "buf/registry/module/v1beta1/commit.proto";
 import "buf/registry/module/v1beta1/file.proto";
 import "buf/registry/module/v1beta1/label.proto";
 import "buf/registry/module/v1beta1/module.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1beta1";
@@ -29,7 +30,9 @@ service UploadService {
   // Upload contents for given set of Modules.
   //
   // Content consists of the Files: .proto files, license files, and documentation files.
-  rpc Upload(UploadRequest) returns (UploadResponse) {}
+  rpc Upload(UploadRequest) returns (UploadResponse) {
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.module.push";
+  }
 }
 
 message UploadRequest {

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -34,12 +34,9 @@ service OrganizationService {
   // List Organizations, usually by User.
   rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // The Permission required depends on the request: listing all Organizations
-    // on the instance (no user_refs) requires the bsr.organization.list
-    // Permission. Listing the Organizations of specific Users requires no
-    // Permission: the response is restricted to the Organizations whose
-    // memberships the caller may read (the bsr.organization-membership.get
-    // Permission).
+    // bsr.organization.list is required if no user_refs are provided.
+    // If user_refs are provided, the response is filtered to the Organizations whose memberships
+    // the caller may read and has bsr.organization-membership.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Organizations.

--- a/buf/registry/owner/v1/organization_service.proto
+++ b/buf/registry/owner/v1/organization_service.proto
@@ -34,7 +34,13 @@ service OrganizationService {
   // List Organizations, usually by User.
   rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.organization.list";
+    // The Permission required depends on the request: listing all Organizations
+    // on the instance (no user_refs) requires the bsr.organization.list
+    // Permission. Listing the Organizations of specific Users requires no
+    // Permission: the response is restricted to the Organizations whose
+    // memberships the caller may read (the bsr.organization-membership.get
+    // Permission).
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Organizations.
   //

--- a/buf/registry/owner/v1/owner_service.proto
+++ b/buf/registry/owner/v1/owner_service.proto
@@ -29,9 +29,8 @@ service OwnerService {
   // Get Users or Organizations by id or name.
   rpc GetOwners(GetOwnersRequest) returns (GetOwnersResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // The Permission required for each OwnerRef depends on the type of the
-    // owner it references: a User requires no Permission, and an Organization
-    // requires the bsr.organization.get Permission.
+    // bsr.organization.get is required for any OwnerRef that resolves to a private Organization.
+    // No Permission is required for an OwnerRef that resolves to a User.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
 }

--- a/buf/registry/owner/v1/owner_service.proto
+++ b/buf/registry/owner/v1/owner_service.proto
@@ -30,8 +30,8 @@ service OwnerService {
   rpc GetOwners(GetOwnersRequest) returns (GetOwnersResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
     // The Permission required for each OwnerRef depends on the type of the
-    // owner it references: a User requires the bsr.user.get Permission, and an
-    // Organization requires the bsr.organization.get Permission.
+    // owner it references: a User requires no Permission, and an Organization
+    // requires the bsr.organization.get Permission.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
 }

--- a/buf/registry/owner/v1/user_service.proto
+++ b/buf/registry/owner/v1/user_service.proto
@@ -28,7 +28,8 @@ service UserService {
   // Get Users by id or name.
   rpc GetUsers(GetUsersRequest) returns (GetUsersResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.user.get";
+    // Users are public on an instance: reading them requires no Permission.
+    option (buf.registry.priv.extension.v1beta1.method).no_required_permission = true;
   }
   // Get the currently authenticated User.
   rpc GetCurrentUser(GetCurrentUserRequest) returns (GetCurrentUserResponse) {
@@ -38,7 +39,11 @@ service UserService {
   // List Users, usually by Organization.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.user.list";
+    // The Permission required depends on the request: listing all Users on the
+    // instance (no organization_refs) requires the bsr.user.list Permission,
+    // and listing the members of an Organization requires the
+    // bsr.organization-membership.list Permission on that Organization.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Users.
   //

--- a/buf/registry/owner/v1/user_service.proto
+++ b/buf/registry/owner/v1/user_service.proto
@@ -39,10 +39,8 @@ service UserService {
   // List Users, usually by Organization.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // The Permission required depends on the request: listing all Users on the
-    // instance (no organization_refs) requires the bsr.user.list Permission,
-    // and listing the members of an Organization requires the
-    // bsr.organization-membership.list Permission on that Organization.
+    // bsr.user.list is required if no organization_refs are provided.
+    // bsr.organization-membership.list is required on each Organization in organization_refs.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Users.

--- a/buf/registry/plugin/v1/plugin_service.proto
+++ b/buf/registry/plugin/v1/plugin_service.proto
@@ -18,6 +18,7 @@ package buf.registry.plugin.v1;
 
 import "buf/registry/owner/v1/owner.proto";
 import "buf/registry/plugin/v1/plugin.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1";
@@ -27,28 +28,35 @@ service PluginService {
   // Get Plugins by id or name.
   rpc GetPlugins(GetPluginsRequest) returns (GetPluginsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
   // List Plugins, usually for a specific Organization.
   rpc ListPlugins(ListPluginsRequest) returns (ListPluginsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // bsr.organization.get is required for any OwnerRef resolving to a private Organization.
+    // The response is filtered to the Plugins the caller may read and has the bsr.plugin.get permission for.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Plugins.
   //
   // This operation is atomic. Either all Plugins are created or an error is returned.
   rpc CreatePlugins(CreatePluginsRequest) returns (CreatePluginsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.create";
   }
   // Update existing Plugins.
   //
   // This operation is atomic. Either all Plugins are updated or an error is returned.
   rpc UpdatePlugins(UpdatePluginsRequest) returns (UpdatePluginsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.update";
   }
   // Delete existing Plugins.
   //
   // This operation is atomic. Either all Plugins are deleted or an error is returned.
   rpc DeletePlugins(DeletePluginsRequest) returns (DeletePluginsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.delete";
   }
 }
 

--- a/buf/registry/plugin/v1/plugin_service.proto
+++ b/buf/registry/plugin/v1/plugin_service.proto
@@ -33,8 +33,9 @@ service PluginService {
   // List Plugins, usually for a specific Organization.
   rpc ListPlugins(ListPluginsRequest) returns (ListPluginsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // bsr.organization.get is required for any OwnerRef resolving to a private Organization.
-    // The response is filtered to the Plugins the caller may read and has the bsr.plugin.get permission for.
+    // bsr.organization.get is required for any OwnerRef that resolves to a private Organization.
+    // The response is filtered to public Plugins and private Plugins that the caller may read and
+    // has bsr.plugin.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Plugins.

--- a/buf/registry/plugin/v1beta1/check_service.proto
+++ b/buf/registry/plugin/v1beta1/check_service.proto
@@ -19,6 +19,7 @@ package buf.registry.plugin.v1beta1;
 import "buf/plugin/check/v1/category.proto";
 import "buf/plugin/check/v1/rule.proto";
 import "buf/registry/plugin/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
@@ -28,10 +29,12 @@ service CheckService {
   // List Rules for a given Plugin, Label, or Commit.
   rpc ListRules(ListRulesRequest) returns (ListRulesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
   // List Categories for a given Plugin, Label, or Commit.
   rpc ListCategories(ListCategoriesRequest) returns (ListCategoriesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
 }
 

--- a/buf/registry/plugin/v1beta1/collection_service.proto
+++ b/buf/registry/plugin/v1beta1/collection_service.proto
@@ -18,6 +18,7 @@ package buf.registry.plugin.v1beta1;
 
 import "buf/registry/plugin/v1beta1/collection.proto";
 import "buf/registry/plugin/v1beta1/plugin.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
@@ -27,14 +28,21 @@ service CollectionService {
   // Get Collections.
   rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // Collections are instance-wide and public: reading them requires no
+    // Permission.
+    option (buf.registry.priv.extension.v1beta1.method).no_required_permission = true;
   }
   // List Collections for a given Plugin.
   rpc ListCollections(ListCollectionsRequest) returns (ListCollectionsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // Collections are instance-wide and public: listing them requires no
+    // Permission.
+    option (buf.registry.priv.extension.v1beta1.method).no_required_permission = true;
   }
   // Get the Collections for the given Plugins.
   rpc GetPluginCollectionAssociations(GetPluginCollectionAssociationsRequest) returns (GetPluginCollectionAssociationsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
 }
 

--- a/buf/registry/plugin/v1beta1/commit_service.proto
+++ b/buf/registry/plugin/v1beta1/commit_service.proto
@@ -19,6 +19,7 @@ package buf.registry.plugin.v1beta1;
 import "buf/registry/plugin/v1beta1/commit.proto";
 import "buf/registry/plugin/v1beta1/digest.proto";
 import "buf/registry/plugin/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
@@ -28,10 +29,12 @@ service CommitService {
   // Get Commits.
   rpc GetCommits(GetCommitsRequest) returns (GetCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
   // List Commits for a given Plugin, Label, or Commit.
   rpc ListCommits(ListCommitsRequest) returns (ListCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
 }
 

--- a/buf/registry/plugin/v1beta1/download_service.proto
+++ b/buf/registry/plugin/v1beta1/download_service.proto
@@ -19,6 +19,7 @@ package buf.registry.plugin.v1beta1;
 import "buf/registry/plugin/v1beta1/commit.proto";
 import "buf/registry/plugin/v1beta1/compression.proto";
 import "buf/registry/plugin/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
@@ -30,6 +31,7 @@ service DownloadService {
   // Contents are WASM modules that are compiled and executed within a suitable runtime.
   rpc Download(DownloadRequest) returns (DownloadResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
 }
 

--- a/buf/registry/plugin/v1beta1/label_service.proto
+++ b/buf/registry/plugin/v1beta1/label_service.proto
@@ -20,6 +20,7 @@ import "buf/registry/plugin/v1beta1/commit.proto";
 import "buf/registry/plugin/v1beta1/digest.proto";
 import "buf/registry/plugin/v1beta1/label.proto";
 import "buf/registry/plugin/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
@@ -29,14 +30,17 @@ service LabelService {
   // Get Labels by id or name.
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
   // List Labels for a given Plugin, Commit or Label.
   rpc ListLabels(ListLabelsRequest) returns (ListLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
   // List the history of a Label.
   rpc ListLabelHistory(ListLabelHistoryRequest) returns (ListLabelHistoryResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
   // Create or update Labels on a Plugin.
   //
@@ -47,6 +51,7 @@ service LabelService {
   // This operation is atomic. Either all Labels are created/updated or an error is returned.
   rpc CreateOrUpdateLabels(CreateOrUpdateLabelsRequest) returns (CreateOrUpdateLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.push";
   }
   // Archive existing Labels.
   //
@@ -55,12 +60,14 @@ service LabelService {
   // It is an error to archive the default Label.
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.push";
   }
   // Unarchive existing Labels.
   //
   // This operation is atomic. Either all Labels are unarchived or an error is returned.
   rpc UnarchiveLabels(UnarchiveLabelsRequest) returns (UnarchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.push";
   }
 }
 

--- a/buf/registry/plugin/v1beta1/plugin_service.proto
+++ b/buf/registry/plugin/v1beta1/plugin_service.proto
@@ -34,10 +34,9 @@ service PluginService {
   // List Plugins, usually for a specific Organization.
   rpc ListPlugins(ListPluginsRequest) returns (ListPluginsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // The Permission required depends on the request: an OwnerRef that names a
-    // private Organization requires the bsr.organization.get Permission on it;
-    // otherwise no Permission is required. The response is filtered to the
-    // Plugins the caller may read (the bsr.plugin.get Permission).
+    // bsr.organization.get is required for any OwnerRef that resolves to a private Organization.
+    // The response is filtered to public Plugins and private Plugins that the caller may read and
+    // has bsr.plugin.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Plugins.

--- a/buf/registry/plugin/v1beta1/plugin_service.proto
+++ b/buf/registry/plugin/v1beta1/plugin_service.proto
@@ -19,6 +19,7 @@ package buf.registry.plugin.v1beta1;
 import "buf/registry/owner/v1/owner.proto";
 import "buf/registry/plugin/v1beta1/collection.proto";
 import "buf/registry/plugin/v1beta1/plugin.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
@@ -28,28 +29,37 @@ service PluginService {
   // Get Plugins by id or name.
   rpc GetPlugins(GetPluginsRequest) returns (GetPluginsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
   // List Plugins, usually for a specific Organization.
   rpc ListPlugins(ListPluginsRequest) returns (ListPluginsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // The Permission required depends on the request: an OwnerRef that names a
+    // private Organization requires the bsr.organization.get Permission on it;
+    // otherwise no Permission is required. The response is filtered to the
+    // Plugins the caller may read (the bsr.plugin.get Permission).
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Plugins.
   //
   // This operation is atomic. Either all Plugins are created or an error is returned.
   rpc CreatePlugins(CreatePluginsRequest) returns (CreatePluginsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.create";
   }
   // Update existing Plugins.
   //
   // This operation is atomic. Either all Plugins are updated or an error is returned.
   rpc UpdatePlugins(UpdatePluginsRequest) returns (UpdatePluginsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.update";
   }
   // Delete existing Plugins.
   //
   // This operation is atomic. Either all Plugins are deleted or an error is returned.
   rpc DeletePlugins(DeletePluginsRequest) returns (DeletePluginsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.delete";
   }
 }
 

--- a/buf/registry/plugin/v1beta1/resource_service.proto
+++ b/buf/registry/plugin/v1beta1/resource_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package buf.registry.plugin.v1beta1;
 
 import "buf/registry/plugin/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1";
@@ -26,6 +27,9 @@ service ResourceService {
   // Get Resources.
   rpc GetResources(GetResourcesRequest) returns (GetResourcesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // Every Resource (Plugin, Label, or Commit) is read from its Plugin, so
+    // every ResourceRef requires the bsr.plugin.get Permission.
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
 }
 

--- a/buf/registry/plugin/v1beta1/resource_service.proto
+++ b/buf/registry/plugin/v1beta1/resource_service.proto
@@ -27,8 +27,6 @@ service ResourceService {
   // Get Resources.
   rpc GetResources(GetResourcesRequest) returns (GetResourcesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // Every Resource (Plugin, Label, or Commit) is read from its Plugin, so
-    // every ResourceRef requires the bsr.plugin.get Permission.
     option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.get";
   }
 }

--- a/buf/registry/plugin/v1beta1/upload_service.proto
+++ b/buf/registry/plugin/v1beta1/upload_service.proto
@@ -30,7 +30,9 @@ service UploadService {
   // Upload contents for given set of Plugins.
   //
   // Contents are expected to be WASM modules.
-  rpc Upload(UploadRequest) returns (UploadResponse) {}
+  rpc Upload(UploadRequest) returns (UploadResponse) {
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.plugin.push";
+  }
 }
 
 message UploadRequest {

--- a/buf/registry/policy/v1/policy_service.proto
+++ b/buf/registry/policy/v1/policy_service.proto
@@ -33,8 +33,9 @@ service PolicyService {
   // List Policies, usually for a specific Organization.
   rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // bsr.organization.get is requried an OrganizationRef that resolves to a private Organization.
-    // The response is filtered to the Policies the caller may read and has the bsr.policy.get for.
+    // bsr.organization.get is required for any OrganizationRef that resolves to a private Organization.
+    // The response is filtered to public Policies and private Policies that the caller may read and
+    // has bsr.policy.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Policies.

--- a/buf/registry/policy/v1/policy_service.proto
+++ b/buf/registry/policy/v1/policy_service.proto
@@ -18,6 +18,7 @@ package buf.registry.policy.v1;
 
 import "buf/registry/owner/v1/organization.proto";
 import "buf/registry/policy/v1/policy.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1";
@@ -27,28 +28,35 @@ service PolicyService {
   // Get Policies by id or name.
   rpc GetPolicies(GetPoliciesRequest) returns (GetPoliciesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
   // List Policies, usually for a specific Organization.
   rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // bsr.organization.get is requried an OrganizationRef that resolves to a private Organization.
+    // The response is filtered to the Policies the caller may read and has the bsr.policy.get for.
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Policies.
   //
   // This operation is atomic. Either all Policies are created or an error is returned.
   rpc CreatePolicies(CreatePoliciesRequest) returns (CreatePoliciesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.create";
   }
   // Update existing Policies.
   //
   // This operation is atomic. Either all Policies are updated or an error is returned.
   rpc UpdatePolicies(UpdatePoliciesRequest) returns (UpdatePoliciesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.update";
   }
   // Delete existing Policies.
   //
   // This operation is atomic. Either all Policies are deleted or an error is returned.
   rpc DeletePolicies(DeletePoliciesRequest) returns (DeletePoliciesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.delete";
   }
 }
 

--- a/buf/registry/policy/v1beta1/commit_service.proto
+++ b/buf/registry/policy/v1beta1/commit_service.proto
@@ -28,10 +28,12 @@ service CommitService {
   // Get Commits.
   rpc GetCommits(GetCommitsRequest) returns (GetCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
   // List Commits for a given Policy.
   rpc ListCommits(ListCommitsRequest) returns (ListCommitsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
 }
 

--- a/buf/registry/policy/v1beta1/download_service.proto
+++ b/buf/registry/policy/v1beta1/download_service.proto
@@ -19,6 +19,7 @@ package buf.registry.policy.v1beta1;
 import "buf/registry/policy/v1beta1/commit.proto";
 import "buf/registry/policy/v1beta1/configuration.proto";
 import "buf/registry/policy/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
@@ -30,6 +31,7 @@ service DownloadService {
   // Contents are a single YAML file.
   rpc Download(DownloadRequest) returns (DownloadResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
 }
 

--- a/buf/registry/policy/v1beta1/label_service.proto
+++ b/buf/registry/policy/v1beta1/label_service.proto
@@ -20,6 +20,7 @@ import "buf/registry/policy/v1beta1/commit.proto";
 import "buf/registry/policy/v1beta1/digest.proto";
 import "buf/registry/policy/v1beta1/label.proto";
 import "buf/registry/policy/v1beta1/resource.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1";
@@ -29,14 +30,17 @@ service LabelService {
   // Get Labels by id or name.
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
   // List Labels for a given Policy, Commit or Label.
   rpc ListLabels(ListLabelsRequest) returns (ListLabelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
   // List the history of a Label.
   rpc ListLabelHistory(ListLabelHistoryRequest) returns (ListLabelHistoryResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
   // Create or update Labels on a Policy.
   //
@@ -47,6 +51,7 @@ service LabelService {
   // This operation is atomic. Either all Labels are created/updated or an error is returned.
   rpc CreateOrUpdateLabels(CreateOrUpdateLabelsRequest) returns (CreateOrUpdateLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.push";
   }
   // Archive existing Labels.
   //
@@ -55,12 +60,14 @@ service LabelService {
   // It is an error to archive the default Label.
   rpc ArchiveLabels(ArchiveLabelsRequest) returns (ArchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.push";
   }
   // Unarchive existing Labels.
   //
   // This operation is atomic. Either all Labels are unarchived or an error is returned.
   rpc UnarchiveLabels(UnarchiveLabelsRequest) returns (UnarchiveLabelsResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.push";
   }
 }
 

--- a/buf/registry/policy/v1beta1/policy_service.proto
+++ b/buf/registry/policy/v1beta1/policy_service.proto
@@ -33,10 +33,9 @@ service PolicyService {
   // List Policies, usually for a specific User or Organization.
   rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    // The Permission required depends on the request: an OwnerRef that names a
-    // private Organization requires the bsr.organization.get Permission on it;
-    // otherwise no Permission is required. The response is filtered to the
-    // Policies the caller may read (the bsr.policy.get Permission).
+    // bsr.organization.get is required for any OwnerRef that resolves to a private Organization.
+    // The response is filtered to public Policies and private Policies that the caller may read and
+    // has bsr.policy.get for.
     option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Policies.

--- a/buf/registry/policy/v1beta1/policy_service.proto
+++ b/buf/registry/policy/v1beta1/policy_service.proto
@@ -28,28 +28,37 @@ service PolicyService {
   // Get Policies by id or name.
   rpc GetPolicies(GetPoliciesRequest) returns (GetPoliciesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
   // List Policies, usually for a specific User or Organization.
   rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    // The Permission required depends on the request: an OwnerRef that names a
+    // private Organization requires the bsr.organization.get Permission on it;
+    // otherwise no Permission is required. The response is filtered to the
+    // Policies the caller may read (the bsr.policy.get Permission).
+    option (buf.registry.priv.extension.v1beta1.method).dynamic_permission = true;
   }
   // Create new Policies.
   //
   // This operation is atomic. Either all Policies are created or an error is returned.
   rpc CreatePolicies(CreatePoliciesRequest) returns (CreatePoliciesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.create";
   }
   // Update exiting Policies.
   //
   // This operation is atomic. Either all Policies are updated or an error is returned.
   rpc UpdatePolicies(UpdatePoliciesRequest) returns (UpdatePoliciesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.update";
   }
   // Delete existing Policies.
   //
   // This operation is atomic. Either all Policies are deleted or an error is returned.
   rpc DeletePolicies(DeletePoliciesRequest) returns (DeletePoliciesResponse) {
     option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.delete";
   }
 }
 

--- a/buf/registry/policy/v1beta1/resource_service.proto
+++ b/buf/registry/policy/v1beta1/resource_service.proto
@@ -26,6 +26,7 @@ service ResourceService {
   // Get Resources.
   rpc GetResources(GetResourcesRequest) returns (GetResourcesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.get";
   }
 }
 

--- a/buf/registry/policy/v1beta1/upload_service.proto
+++ b/buf/registry/policy/v1beta1/upload_service.proto
@@ -31,7 +31,7 @@ service UploadService {
   //
   // Contents are expected to be a single YAML file.
   rpc Upload(UploadRequest) returns (UploadResponse) {
-    // bsr.plugin.get is required for any private Plugin refrenced.
+    // bsr.plugin.get is required for any private Plugin referenced.
     option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.push";
   }
 }

--- a/buf/registry/policy/v1beta1/upload_service.proto
+++ b/buf/registry/policy/v1beta1/upload_service.proto
@@ -30,7 +30,10 @@ service UploadService {
   // Upload contents for given set of Policies.
   //
   // Contents are expected to be a single YAML file.
-  rpc Upload(UploadRequest) returns (UploadResponse) {}
+  rpc Upload(UploadRequest) returns (UploadResponse) {
+    // bsr.plugin.get is required for any private Plugin refrenced.
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.policy.push";
+  }
 }
 
 message UploadRequest {


### PR DESCRIPTION
This PR
* updates `Permission`'s docs to show that it can only limit a token's capability
* adds `included_permissions` to `Permission`. One example is that `bsr.organization.update` includes `bsr.organization.get`
* updates permission annotations

Targets the iam-v1 branch