### PR TITLE
Update ScopedPermission.permissions to be repeated

### DIFF
--- a/buf/registry/iam/v1/token.proto
+++ b/buf/registry/iam/v1/token.proto
@@ -77,23 +77,25 @@ message Token {
   repeated ScopedPermission scoped_permissions = 7 [
     (buf.validate.field).repeated.max_items = 250,
     (buf.validate.field).cel = {
-      id: "scoped_permissions.unique"
-      message: "scoped permissions must have unique scope and permission pairs"
-      expression: "this.map(sp, (has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id) + '|' + sp.permission).unique()"
+      id: "scoped_permissions.unique_scope"
+      message: "scoped permissions must have unique scopes"
+      expression: "this.map(sp, has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id).unique()"
     }
   ];
 }
 
-// A permission that applies within a specific Scope.
+// A set of permissions that apply within a specific Scope.
 //
 // ScopedPermissions restrict a Token to a subset of its owning User's permissions.
 message ScopedPermission {
-  // The Scope that the permission applies to.
+  // The Scope that the permissions apply to.
   Scope scope = 1 [(buf.validate.field).required = true];
-  // The permission allowed within the Scope (e.g. "bsr.module.delete").
-  string permission = 2 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.(buf.registry.priv.validate.v1beta1.permission_name) = true
+  // The permissions allowed within the Scope (e.g. "bsr.module.delete").
+  repeated string permissions = 2 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 100,
+    (buf.validate.field).repeated.unique = true,
+    (buf.validate.field).repeated.items.string.(buf.registry.priv.validate.v1beta1.permission_name) = true
   ];
 }
 

--- a/buf/registry/iam/v1/token.proto
+++ b/buf/registry/iam/v1/token.proto
@@ -74,7 +74,7 @@ message Token {
   //
   // In other words, ScopedPermissions can restrict the permissions of a Token,
   // but cannot add any permissions that the User does not already have.
-  repeated ScopedPermission scoped_permissions = 7 [
+  repeated ScopedPermissions scoped_permissions = 7 [
     (buf.validate.field).repeated.max_items = 250,
     (buf.validate.field).cel = {
       id: "scoped_permissions.unique_scope"
@@ -87,7 +87,7 @@ message Token {
 // A set of permissions that apply within a specific Scope.
 //
 // ScopedPermissions restrict a Token to a subset of its owning User's permissions.
-message ScopedPermission {
+message ScopedPermissions {
   // The Scope that the permissions apply to.
   Scope scope = 1 [(buf.validate.field).required = true];
   // The permissions allowed within the Scope (e.g. "bsr.module.delete").

--- a/buf/registry/iam/v1/token_service.proto
+++ b/buf/registry/iam/v1/token_service.proto
@@ -168,7 +168,7 @@ message CreateTokensRequest {
     //
     // In other words, ScopedPermissions can restrict the permissions of a Token,
     // but cannot add any permissions that the User does not already have.
-    repeated ScopedPermission scoped_permissions = 4 [
+    repeated ScopedPermissions scoped_permissions = 4 [
       (buf.validate.field).repeated.max_items = 250,
       (buf.validate.field).cel = {
         id: "scoped_permissions.unique_scope"
@@ -208,7 +208,7 @@ message UpdateTokensRequest {
     // A replacement list of ScopedPermissions.
     //
     // A message is used so that an unset field can be distinguished from an empty list.
-    message ScopedPermissions {
+    message ScopedPermissionsList {
       // The scoped permissions of the Token.
       //
       // If empty, the Token has no declared permission restrictions and its effective
@@ -219,7 +219,7 @@ message UpdateTokensRequest {
       //
       // In other words, ScopedPermissions can restrict the permissions of a Token,
       // but cannot add any permissions that the User does not already have.
-      repeated ScopedPermission scoped_permissions = 1 [
+      repeated ScopedPermissions scoped_permissions = 1 [
         (buf.validate.field).repeated.max_items = 250,
         (buf.validate.field).cel = {
           id: "scoped_permissions.unique_scope"
@@ -241,7 +241,7 @@ message UpdateTokensRequest {
     //
     // If not set, the scoped permissions are not updated. If set with an empty list, all
     // permission restrictions are removed from the Token.
-    ScopedPermissions scoped_permissions = 3;
+    ScopedPermissionsList scoped_permissions = 3;
   }
   // The Tokens to update.
   repeated Value values = 1 [

--- a/buf/registry/iam/v1/token_service.proto
+++ b/buf/registry/iam/v1/token_service.proto
@@ -171,9 +171,9 @@ message CreateTokensRequest {
     repeated ScopedPermission scoped_permissions = 4 [
       (buf.validate.field).repeated.max_items = 250,
       (buf.validate.field).cel = {
-        id: "scoped_permissions.unique"
-        message: "scoped permissions must have unique scope and permission pairs"
-        expression: "this.map(sp, (has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id) + '|' + sp.permission).unique()"
+        id: "scoped_permissions.unique_scope"
+        message: "scoped permissions must have unique scopes"
+        expression: "this.map(sp, has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id).unique()"
       }
     ];
   }
@@ -222,9 +222,9 @@ message UpdateTokensRequest {
       repeated ScopedPermission scoped_permissions = 1 [
         (buf.validate.field).repeated.max_items = 250,
         (buf.validate.field).cel = {
-          id: "scoped_permissions.unique"
-          message: "scoped permissions must have unique scope and permission pairs"
-          expression: "this.map(sp, (has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id) + '|' + sp.permission).unique()"
+          id: "scoped_permissions.unique_scope"
+          message: "scoped permissions must have unique scopes"
+          expression: "this.map(sp, has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id).unique()"
         }
       ];
     }


### PR DESCRIPTION
When creating a scoped token, it is typical to list multiple permissions for a single scope (resource). Update `permission` to `permissions` and change the field to repeated to better match the shape of requests to create tokens.