### PR TITLE
Add protos for a v1 trust credentials API

### DIFF
--- a/buf/registry/audit/v1/event.proto
+++ b/buf/registry/audit/v1/event.proto
@@ -19,6 +19,8 @@ package buf.registry.audit.v1;
 import "buf/registry/admin/v1/settings.proto";
 import "buf/registry/iam/v1/module_contributor.proto";
 import "buf/registry/iam/v1/organization_membership.proto";
+import "buf/registry/iam/v1/token.proto";
+import "buf/registry/iam/v1/trust_credential.proto";
 import "buf/registry/module/v1/module.proto";
 import "buf/registry/plugin/v1/plugin.proto";
 import "buf/registry/policy/v1/policy.proto";
@@ -44,7 +46,7 @@ message Actor {
 
 // ResourceType is the type of the resource that was affected by the audited event.
 //
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 enum ResourceType {
   RESOURCE_TYPE_UNSPECIFIED = 0;
   RESOURCE_TYPE_USER = 1;
@@ -71,6 +73,7 @@ enum ResourceType {
   RESOURCE_TYPE_SDK_PLUGIN_CONSTRAINT = 21;
   RESOURCE_TYPE_AUTHORIZATION_REQUEST = 23;
   RESOURCE_TYPE_RECOMMENDED_SDK = 24;
+  RESOURCE_TYPE_TRUST_CREDENTIAL = 25;
 }
 
 // Resource is the affected resource by the audited event.
@@ -85,7 +88,7 @@ message Resource {
 
 // EventType is the type of audited event.
 //
-// [#next-free-field: 88]
+// [#next-free-field: 91]
 enum EventType {
   EVENT_TYPE_UNSPECIFIED = 0;
   EVENT_TYPE_ORGANIZATION_CREATED = 1;
@@ -175,6 +178,9 @@ enum EventType {
   EVENT_TYPE_AUTHORIZATION_REQUEST_DENIED = 85;
   EVENT_TYPE_RECOMMENDED_SDK_ADDED = 86;
   EVENT_TYPE_RECOMMENDED_SDK_REMOVED = 87;
+  EVENT_TYPE_TRUST_CREDENTIAL_CREATED = 88;
+  EVENT_TYPE_TRUST_CREDENTIAL_DELETED = 89;
+  EVENT_TYPE_TRUST_CREDENTIAL_UPDATED = 90;
 }
 
 // EventMetadata provides additional details about the audited event.
@@ -190,7 +196,7 @@ message EventMetadata {
 // it happened, who did it, which resource was affected, and more contextual information on the
 // event.
 //
-// [#next-free-field: 94]
+// [#next-free-field: 97]
 message Event {
   // Unique id of the audited event.
   string event_id = 1;
@@ -295,6 +301,9 @@ message Event {
     PayloadAuthorizationRequestDenied authorization_request_denied = 91;
     PayloadRecommendedSDKAdded recommended_sdk_added = 92;
     PayloadRecommendedSDKRemoved recommended_sdk_removed = 93;
+    PayloadTrustCredentialCreated trust_credential_created = 94;
+    PayloadTrustCredentialDeleted trust_credential_deleted = 95;
+    PayloadTrustCredentialUpdated trust_credential_updated = 96;
   }
 }
 
@@ -1137,4 +1146,48 @@ message PayloadRecommendedSDKRemoved {
   string plugin_id = 7;
   // plugin_name is the name of the plugin of the recommended SDK.
   string plugin_name = 8;
+}
+
+message PayloadTrustCredentialCreated {
+  // owner_id is the id of the owner of the trust credential.
+  string owner_id = 1;
+  // issuer_url is the url of the OIDC issuer whose tokens the trust credential accepts.
+  string issuer_url = 2;
+  // subject is the sub claim a workload's OIDC token must match, i.e. exactly which workloads this
+  // grant trusts.
+  string subject = 3;
+  // custom_claims are the additional claims a workload's OIDC token must carry, if any.
+  repeated buf.registry.iam.v1.CustomClaim custom_claims = 4;
+  // scoped_permissions are the permissions carried by the tokens the trust credential mints.
+  // Empty means the tokens carry the owner's permissions resolved at request time.
+  repeated buf.registry.iam.v1.ScopedPermissions scoped_permissions = 5;
+}
+
+message PayloadTrustCredentialDeleted {
+  // owner_id is the id of the owner of the trust credential.
+  string owner_id = 1;
+  // issuer_url is the url of the OIDC issuer whose tokens the trust credential accepted.
+  string issuer_url = 2;
+  // subject is the sub claim the trust credential required when it was deleted.
+  string subject = 3;
+  // custom_claims are the additional claims it required, if any.
+  repeated buf.registry.iam.v1.CustomClaim custom_claims = 4;
+  // scoped_permissions are the permissions the trust credential's tokens carried.
+  repeated buf.registry.iam.v1.ScopedPermissions scoped_permissions = 5;
+}
+
+message PayloadTrustCredentialUpdated {
+  // owner_id is the id of the owner of the trust credential.
+  string owner_id = 1;
+  // issuer_url is the url of the OIDC issuer the trust credential accepts tokens from after
+  // the update.
+  string issuer_url = 2;
+  // subject is the sub claim the trust credential requires after the update, i.e. exactly which
+  // workloads it trusts from now on.
+  string subject = 3;
+  // custom_claims are the additional claims required after the update, if any.
+  repeated buf.registry.iam.v1.CustomClaim custom_claims = 4;
+  // scoped_permissions are the permissions carried by the tokens the trust credential mints
+  // after the update.
+  repeated buf.registry.iam.v1.ScopedPermissions scoped_permissions = 5;
 }

--- a/buf/registry/iam/v1/trust_credential.proto
+++ b/buf/registry/iam/v1/trust_credential.proto
@@ -1,0 +1,206 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.iam.v1;
+
+import "buf/registry/iam/v1/token.proto";
+import "buf/registry/owner/v1/user.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/iam/v1";
+
+// A TrustCredential on the BSR.
+//
+// A TrustCredential is a trust rule that allows a workload to authenticate as its owning User by
+// presenting an OIDC token signed by a WorkloadIdentityIssuer, instead of a Token secret.
+//
+// A workload's OIDC token is accepted only if its sub claim matches subject and every CustomClaim
+// matches, so a TrustCredential reaches exactly as far as those allow. The subject is what pins the
+// credential to a workload; CustomClaims narrow it further.
+//
+// A TrustCredential's name, issuer_url, subject, CustomClaims, and ScopedPermissions may
+// be updated after creation. All other properties are immutable.
+//
+// Exchanging a workload's OIDC token mints a Token that authenticates as the owning User and that
+// carries the TrustCredential's ScopedPermissions. Deleting a TrustCredential revokes the
+// Tokens already minted through it. Updating one does not: a Token keeps the ScopedPermissions it
+// was minted with until it expires, so a narrowed TrustCredential governs only the Tokens minted
+// after the change.
+message TrustCredential {
+  option (buf.registry.priv.extension.v1beta1.message).response_only = true;
+
+  // The id of the TrustCredential.
+  string id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The time the TrustCredential was created.
+  google.protobuf.Timestamp create_time = 2 [(buf.validate.field).required = true];
+  // The last time the TrustCredential was updated.
+  google.protobuf.Timestamp update_time = 3 [(buf.validate.field).required = true];
+  // The name of the TrustCredential.
+  //
+  // Names are unique among the TrustCredentials owned by a User.
+  string name = 4 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.min_len = 3,
+    (buf.validate.field).string.max_len = 256
+  ];
+  // The id of the User that owns the TrustCredential.
+  //
+  // Tokens minted through the TrustCredential authenticate as this User.
+  string user_id = 5 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.tuuid = true
+  ];
+  // The WorkloadIdentityIssuer whose OIDC tokens the TrustCredential accepts.
+  //
+  // WORKLOAD_IDENTITY_ISSUER_CUSTOM means the issuer is not one this instance knows, and issuer_url
+  // is the operator's own.
+  WorkloadIdentityIssuer issuer = 6 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).enum.defined_only = true
+  ];
+  // The url of the WorkloadIdentityIssuer whose OIDC tokens the TrustCredential accepts.
+  //
+  // This is compared against the iss claim of the workload's OIDC token exactly. For a known
+  // issuer it is the url that issuer signs with, which the instance fills in.
+  string issuer_url = 7 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uri = true,
+    (buf.validate.field).string.max_len = 255
+  ];
+  // The subject that a workload's OIDC token must carry in its sub claim.
+  //
+  // Its shape is the issuer's: GitHub Actions, for instance, writes
+  // "repo:acme/protos:ref:refs/heads/main", so "repo:acme/protos:*" trusts every workflow in that
+  // one repository.
+  //
+  // A "*" matches any run of characters, anywhere in the subject, and every other character must
+  // match exactly. Only a subject of nothing but wildcards is refused, since it would trust
+  // everything the issuer signs. There is no restriction on where a wildcard may fall: the shape of
+  // a sub claim is the issuer's to define, and a subject that is a bare numeric account id has no
+  // segment to widen past.
+  string subject = 8 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.max_len = 1000
+  ];
+  // Additional claims that a workload's OIDC token must carry.
+  //
+  // Every CustomClaim must match. Unlike subject these are optional: they narrow a credential that
+  // subject alone does not pin tightly enough, for example to one environment or one branch.
+  repeated CustomClaim custom_claims = 9 [
+    (buf.validate.field).repeated.max_items = 20,
+    (buf.validate.field).cel = {
+      id: "custom_claims.unique_key"
+      message: "custom claims must have unique keys"
+      expression: "this.map(custom_claim, custom_claim.key).unique()"
+    }
+  ];
+  // The scoped permissions of the Tokens minted through the TrustCredential.
+  //
+  // If empty, the minted Tokens have no declared permission restrictions and their effective
+  // permissions are the owning User's permissions resolved at request time.
+  //
+  // Otherwise, a minted Token's effective permissions are the intersection of these declared
+  // permissions and the owning User's permissions resolved at request time.
+  //
+  // In other words, ScopedPermissions can restrict the permissions of the minted Tokens,
+  // but cannot add any permissions that the User does not already have.
+  repeated ScopedPermissions scoped_permissions = 10 [
+    (buf.validate.field).repeated.max_items = 250,
+    (buf.validate.field).cel = {
+      id: "scoped_permissions.unique_scope"
+      message: "scoped permissions must have unique scopes"
+      expression: "this.map(sp, has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id).unique()"
+    }
+  ];
+}
+
+// A requirement on a single claim of a workload's OIDC token.
+//
+// A CustomClaim matches when the claim named by key is present on the OIDC token and its value is
+// matched by value.
+message CustomClaim {
+  // The name of the claim, for example "repository".
+  //
+  // Any claim the issuer sets may be named. A nested claim is named by its path, joined with dots,
+  // so "acme.tier" names the "tier" field of the "acme" object. A name that itself contains a dot
+  // is escaped by surrounding it in double quotes, so "\"open.id\".username" names the "username"
+  // field of the "open.id" object.
+  string key = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.max_len = 250
+  ];
+  // The value that the claim must have.
+  //
+  // A "*" matches any run of characters and every other character must match exactly. A value of
+  // only wildcards is refused, as it would place no restriction on the claim at all.
+  string value = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.max_len = 1000
+  ];
+}
+
+// A WorkloadIdentityIssuer whose OIDC tokens an instance accepts in exchange for a Token.
+//
+// A known issuer names a platform this instance already understands, so a TrustCredential naming
+// one does not carry a url: the instance supplies the url that platform signs with.
+enum WorkloadIdentityIssuer {
+  WORKLOAD_IDENTITY_ISSUER_UNSPECIFIED = 0;
+  // An OIDC issuer this instance does not know, named by its own url.
+  //
+  // The url must be https and carry no credentials, query, or fragment. It is compared against the
+  // iss claim exactly, so a trailing slash is kept if the issuer has one.
+  //
+  // This is 1 so that the known issuers below occupy a contiguous range from 2 upward and adding
+  // one is just the next number.
+  WORKLOAD_IDENTITY_ISSUER_CUSTOM = 1;
+  // GitHub Actions.
+  //
+  // Its sub claim is colon-delimited and pins the exact workflow, for example
+  // "repo:acme/protos:ref:refs/heads/main".
+  WORKLOAD_IDENTITY_ISSUER_GITHUB = 2;
+}
+
+// TrustCredentialRef is a reference to a TrustCredential, either an id or a name.
+//
+// This is used in requests.
+message TrustCredentialRef {
+  option (buf.registry.priv.extension.v1beta1.message).request_only = true;
+
+  // The name of a TrustCredential owned by a User.
+  message Name {
+    // The reference to the user which owns the trust credential.
+    buf.registry.owner.v1.UserRef user_ref = 1 [(buf.validate.field).required = true];
+    // The name of the trust credential.
+    string name = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.min_len = 3,
+      (buf.validate.field).string.max_len = 256
+    ];
+  }
+
+  oneof value {
+    option (buf.validate.oneof).required = true;
+    // The id of the TrustCredential.
+    string id = 1 [(buf.validate.field).string.tuuid = true];
+    // The name of the user's trust credential.
+    Name name = 2;
+  }
+}

--- a/buf/registry/iam/v1/trust_credential.proto
+++ b/buf/registry/iam/v1/trust_credential.proto
@@ -30,17 +30,18 @@ option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/r
 // presenting an OIDC token signed by a WorkloadIdentityIssuer, instead of a Token secret.
 //
 // A workload's OIDC token is accepted only if its sub claim matches subject and every CustomClaim
-// matches, so a TrustCredential reaches exactly as far as those allow. The subject is what pins the
-// credential to a workload; CustomClaims narrow it further.
+// matches. The subject is what pins the credential to a workload and CustomClaims narrow it
+// further.
 //
-// A TrustCredential's name, issuer_url, subject, CustomClaims, and ScopedPermissions may
+// A TrustCredential's name, issuer_url, subject, custom_claims, and scoped_permissions may
 // be updated after creation. All other properties are immutable.
 //
 // Exchanging a workload's OIDC token mints a Token that authenticates as the owning User and that
-// carries the TrustCredential's ScopedPermissions. Deleting a TrustCredential revokes the
-// Tokens already minted through it. Updating one does not: a Token keeps the ScopedPermissions it
-// was minted with until it expires, so a narrowed TrustCredential governs only the Tokens minted
-// after the change.
+// carries the TrustCredential's scoped_permissions. Deleting a TrustCredential revokes the
+// Tokens already minted through it. Updating one does not: revoking on update would fail every job
+// mid-run whenever a credential is narrowed, and a minted Token lives at most an hour, so the
+// impact of the old permissions is negligible. A narrowed TrustCredential governs the Tokens
+// minted after the change.
 message TrustCredential {
   option (buf.registry.priv.extension.v1beta1.message).response_only = true;
 
@@ -83,22 +84,28 @@ message TrustCredential {
   string issuer_url = 7 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.uri = true,
+    (buf.validate.field).string.prefix = "https://",
     (buf.validate.field).string.max_len = 255
   ];
   // The subject that a workload's OIDC token must carry in its sub claim.
   //
   // Its shape is the issuer's: GitHub Actions, for instance, writes
   // "repo:acme/protos:ref:refs/heads/main", so "repo:acme/protos:*" trusts every workflow in that
-  // one repository.
+  // one repository. GitHub repositories created after July 2026 carry immutable ids in the names,
+  // such as "repo:acme@123/protos@456:ref:refs/heads/main".
   //
   // A "*" matches any run of characters, anywhere in the subject, and every other character must
   // match exactly. Only a subject of nothing but wildcards is refused, since it would trust
   // everything the issuer signs. There is no restriction on where a wildcard may fall: the shape of
-  // a sub claim is the issuer's to define, and a subject that is a bare numeric account id has no
-  // segment to widen past.
+  // a sub claim is the issuer's to define.
   string subject = 8 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 1000
+    (buf.validate.field).string.max_len = 1000,
+    (buf.validate.field).cel = {
+      id: "subject.not_only_wildcards"
+      message: "subject must contain a character other than *"
+      expression: "!this.matches('^[*]+$')"
+    }
   ];
   // Additional claims that a workload's OIDC token must carry.
   //
@@ -153,7 +160,12 @@ message CustomClaim {
   // only wildcards is refused, as it would place no restriction on the claim at all.
   string value = 2 [
     (buf.validate.field).required = true,
-    (buf.validate.field).string.max_len = 1000
+    (buf.validate.field).string.max_len = 1000,
+    (buf.validate.field).cel = {
+      id: "value.not_only_wildcards"
+      message: "value must contain a character other than *"
+      expression: "!this.matches('^[*]+$')"
+    }
   ];
 }
 
@@ -174,7 +186,8 @@ enum WorkloadIdentityIssuer {
   // GitHub Actions.
   //
   // Its sub claim is colon-delimited and pins the exact workflow, for example
-  // "repo:acme/protos:ref:refs/heads/main".
+  // "repo:acme/protos:ref:refs/heads/main". Repositories created after July 2026 carry immutable
+  // ids in the names, such as "repo:acme@123/protos@456:ref:refs/heads/main".
   WORKLOAD_IDENTITY_ISSUER_GITHUB = 2;
 }
 

--- a/buf/registry/iam/v1/trust_credential.proto
+++ b/buf/registry/iam/v1/trust_credential.proto
@@ -180,8 +180,6 @@ enum WorkloadIdentityIssuer {
   // The url must be https and carry no credentials, query, or fragment. It is compared against the
   // iss claim exactly, so a trailing slash is kept if the issuer has one.
   //
-  // This is 1 so that the known issuers below occupy a contiguous range from 2 upward and adding
-  // one is just the next number.
   WORKLOAD_IDENTITY_ISSUER_CUSTOM = 1;
   // GitHub Actions.
   //

--- a/buf/registry/iam/v1/trust_credential_service.proto
+++ b/buf/registry/iam/v1/trust_credential_service.proto
@@ -31,7 +31,7 @@ service TrustCredentialService {
     option idempotency_level = NO_SIDE_EFFECTS;
     option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.trust-credential.get";
   }
-  // List TrustCredentials, usually for a User.
+  // List TrustCredentials for the given Users.
   rpc ListTrustCredentials(ListTrustCredentialsRequest) returns (ListTrustCredentialsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
     option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.trust-credential.list";
@@ -122,9 +122,16 @@ message ListTrustCredentialsResponse {
 message CreateTrustCredentialsRequest {
   // An individual request to create a TrustCredential.
   message Value {
+    option (buf.validate.message).cel = {
+      id: "issuer_url.custom_only"
+      message: "issuer_url is required for a custom issuer and must be empty otherwise"
+      // WORKLOAD_IDENTITY_ISSUER_CUSTOM is 1.
+      expression: "(this.issuer == 1) == (this.issuer_url != '')"
+    };
+
     // The User that will own the TrustCredential.
     //
-    // Must be a machine User.
+    // Must be a bot User.
     buf.registry.owner.v1.UserRef user_ref = 1 [(buf.validate.field).required = true];
     // The name of the TrustCredential.
     string name = 2 [
@@ -148,16 +155,24 @@ message CreateTrustCredentialsRequest {
     string issuer_url = 4 [
       (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).string.uri = true,
+      (buf.validate.field).string.prefix = "https://",
       (buf.validate.field).string.max_len = 255
     ];
     // The subject that a workload's OIDC token must carry in its sub claim.
     //
     // Its shape is the issuer's: GitHub Actions, for instance, writes
-    // "repo:acme/protos:ref:refs/heads/main". A "*" matches any run of characters and may fall
-    // anywhere, but a subject of nothing but wildcards is refused.
+    // "repo:acme/protos:ref:refs/heads/main", or for repositories created after July 2026,
+    // "repo:acme@123/protos@456:ref:refs/heads/main". A "*" matches
+    // any run of characters and may fall anywhere, but a subject of nothing but wildcards is
+    // refused.
     string subject = 5 [
       (buf.validate.field).required = true,
-      (buf.validate.field).string.max_len = 1000
+      (buf.validate.field).string.max_len = 1000,
+      (buf.validate.field).cel = {
+        id: "subject.not_only_wildcards"
+        message: "subject must contain a character other than *"
+        expression: "!this.matches('^[*]+$')"
+      }
     ];
     // Additional claims that a workload's OIDC token must carry.
     //
@@ -205,6 +220,13 @@ message CreateTrustCredentialsResponse {
 message UpdateTrustCredentialsRequest {
   // An individual request to update a TrustCredential.
   message Value {
+    option (buf.validate.message).cel = {
+      id: "issuer_url.custom_only"
+      message: "issuer_url must be unset when setting a known issuer, which supplies its own url"
+      // WORKLOAD_IDENTITY_ISSUER_CUSTOM is 1.
+      expression: "!has(this.issuer) || this.issuer == 1 || !has(this.issuer_url)"
+    };
+
     // A replacement list of CustomClaims.
     //
     // A message is used so that an unset field can be distinguished from an empty list.
@@ -267,13 +289,21 @@ message UpdateTrustCredentialsRequest {
     // sending an empty string; the instance drops the url the TrustCredential used to carry.
     optional string issuer_url = 4 [
       (buf.validate.field).string.uri = true,
+      (buf.validate.field).string.prefix = "https://",
       (buf.validate.field).string.max_len = 255
     ];
     // The subject that a workload's OIDC token must carry in its sub claim.
     //
     // If not set, the subject is not updated. It can never be cleared: a TrustCredential always
     // pins a subject.
-    optional string subject = 5 [(buf.validate.field).string.max_len = 1000];
+    optional string subject = 5 [
+      (buf.validate.field).string.max_len = 1000,
+      (buf.validate.field).cel = {
+        id: "subject.not_only_wildcards"
+        message: "subject must contain a character other than *"
+        expression: "!this.matches('^[*]+$')"
+      }
+    ];
     // The CustomClaims of the TrustCredential, replacing all existing CustomClaims.
     //
     // If not set, the CustomClaims are not updated. If set with an empty list, they are all

--- a/buf/registry/iam/v1/trust_credential_service.proto
+++ b/buf/registry/iam/v1/trust_credential_service.proto
@@ -1,0 +1,308 @@
+// Copyright 2023-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package buf.registry.iam.v1;
+
+import "buf/registry/iam/v1/token.proto";
+import "buf/registry/iam/v1/trust_credential.proto";
+import "buf/registry/owner/v1/user.proto";
+import "buf/registry/priv/extension/v1beta1/extension.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/iam/v1";
+
+// Operate on TrustCredentials.
+service TrustCredentialService {
+  // Get TrustCredentials by id or name.
+  rpc GetTrustCredentials(GetTrustCredentialsRequest) returns (GetTrustCredentialsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.trust-credential.get";
+  }
+  // List TrustCredentials, usually for a User.
+  rpc ListTrustCredentials(ListTrustCredentialsRequest) returns (ListTrustCredentialsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.trust-credential.list";
+  }
+  // Create new TrustCredentials.
+  //
+  // This operation is atomic. Either all TrustCredentials are created or an error is returned.
+  //
+  // This operation is not idempotent: TrustCredential names are unique among the
+  // TrustCredentials owned by a User, so a repeated call returns an error.
+  rpc CreateTrustCredentials(CreateTrustCredentialsRequest) returns (CreateTrustCredentialsResponse) {
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.trust-credential.create";
+  }
+  // Update existing TrustCredentials.
+  //
+  // The Tokens already minted through a TrustCredential are not revoked: each keeps the
+  // ScopedPermissions it was minted with until it expires, so an update governs only the Tokens
+  // minted after it. Delete the TrustCredential to withdraw trust at once.
+  //
+  // This operation is atomic. Either all TrustCredentials are updated or an error is returned.
+  rpc UpdateTrustCredentials(UpdateTrustCredentialsRequest) returns (UpdateTrustCredentialsResponse) {
+    option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.trust-credential.update";
+  }
+  // Delete existing TrustCredentials.
+  //
+  // The Tokens minted through a TrustCredential are revoked along with it, so withdrawing trust
+  // takes effect at once rather than at the end of the last minted Token's lifetime.
+  //
+  // This operation is atomic. Either all TrustCredentials are deleted or an error is returned.
+  rpc DeleteTrustCredentials(DeleteTrustCredentialsRequest) returns (DeleteTrustCredentialsResponse) {
+    option idempotency_level = IDEMPOTENT;
+    option (buf.registry.priv.extension.v1beta1.method).required_permission = "bsr.trust-credential.delete";
+  }
+}
+
+message GetTrustCredentialsRequest {
+  // The TrustCredentials to request.
+  repeated TrustCredentialRef trust_credential_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message GetTrustCredentialsResponse {
+  // The retrieved TrustCredentials in the same order as requested.
+  repeated TrustCredential trust_credentials = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message ListTrustCredentialsRequest {
+  // The list order.
+  enum Order {
+    ORDER_UNSPECIFIED = 0;
+    // Order by create_time latest to earliest.
+    ORDER_CREATE_TIME_DESC = 1;
+    // Order by create_time earliest to latest.
+    ORDER_CREATE_TIME_ASC = 2;
+  }
+
+  // The maximum number of items to return.
+  //
+  // The default value is 10.
+  uint32 page_size = 1 [(buf.validate.field).uint32.lte = 250];
+  // The page to start from.
+  //
+  // If empty, the first page is returned.
+  string page_token = 2 [(buf.validate.field).string.max_len = 4096];
+  // The Users to list TrustCredentials for.
+  repeated buf.registry.owner.v1.UserRef user_refs = 3 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+  // The order to return the TrustCredentials.
+  //
+  // If not specified, defaults to ORDER_CREATE_TIME_DESC.
+  Order order = 4 [(buf.validate.field).enum.defined_only = true];
+}
+
+message ListTrustCredentialsResponse {
+  // The next page token.
+  //
+  // If empty, there are no more pages.
+  string next_page_token = 1 [(buf.validate.field).string.max_len = 4096];
+  // The list of TrustCredentials.
+  repeated TrustCredential trust_credentials = 2;
+}
+
+message CreateTrustCredentialsRequest {
+  // An individual request to create a TrustCredential.
+  message Value {
+    // The User that will own the TrustCredential.
+    //
+    // Must be a machine User.
+    buf.registry.owner.v1.UserRef user_ref = 1 [(buf.validate.field).required = true];
+    // The name of the TrustCredential.
+    string name = 2 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.min_len = 3,
+      (buf.validate.field).string.max_len = 256
+    ];
+    // The WorkloadIdentityIssuer whose OIDC tokens the TrustCredential accepts.
+    //
+    // For a known issuer the instance supplies the url that platform signs with, and issuer_url
+    // must be empty. For WORKLOAD_IDENTITY_ISSUER_CUSTOM, issuer_url is required.
+    WorkloadIdentityIssuer issuer = 3 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).enum.defined_only = true
+    ];
+    // The url of the OIDC issuer whose tokens the TrustCredential accepts.
+    //
+    // Required when issuer is WORKLOAD_IDENTITY_ISSUER_CUSTOM, and must be empty otherwise. It must
+    // be https and carry no credentials, query, or fragment. It is compared against the iss claim
+    // of the workload's OIDC token exactly, so a trailing slash is kept if the issuer has one.
+    string issuer_url = 4 [
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+      (buf.validate.field).string.uri = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The subject that a workload's OIDC token must carry in its sub claim.
+    //
+    // Its shape is the issuer's: GitHub Actions, for instance, writes
+    // "repo:acme/protos:ref:refs/heads/main". A "*" matches any run of characters and may fall
+    // anywhere, but a subject of nothing but wildcards is refused.
+    string subject = 5 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).string.max_len = 1000
+    ];
+    // Additional claims that a workload's OIDC token must carry.
+    //
+    // Every CustomClaim must match. These are optional and narrow a credential that subject alone
+    // does not pin tightly enough.
+    repeated CustomClaim custom_claims = 6 [
+      (buf.validate.field).repeated.max_items = 20,
+      (buf.validate.field).cel = {
+        id: "custom_claims.unique_key"
+        message: "custom claims must have unique keys"
+        expression: "this.map(custom_claim, custom_claim.key).unique()"
+      }
+    ];
+    // The scoped permissions of the Tokens minted through the TrustCredential.
+    //
+    // If empty, the minted Tokens have no declared permission restrictions and their effective
+    // permissions are the owner's permissions resolved at request time.
+    //
+    // Otherwise, a minted Token's effective permissions are the intersection of these declared
+    // permissions and the owner's permissions resolved at request time.
+    //
+    // In other words, ScopedPermissions can restrict the permissions of the minted Tokens,
+    // but cannot add any permissions that the User does not already have.
+    repeated ScopedPermissions scoped_permissions = 7 [
+      (buf.validate.field).repeated.max_items = 250,
+      (buf.validate.field).cel = {
+        id: "scoped_permissions.unique_scope"
+        message: "scoped permissions must have unique scopes"
+        expression: "this.map(sp, has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id).unique()"
+      }
+    ];
+  }
+  // The TrustCredentials to create.
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message CreateTrustCredentialsResponse {
+  // The created TrustCredentials in the same order as given on the request.
+  repeated TrustCredential trust_credentials = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message UpdateTrustCredentialsRequest {
+  // An individual request to update a TrustCredential.
+  message Value {
+    // A replacement list of CustomClaims.
+    //
+    // A message is used so that an unset field can be distinguished from an empty list.
+    message CustomClaimsList {
+      // Additional claims that a workload's OIDC token must carry.
+      //
+      // Every CustomClaim must match. An empty list removes them all, leaving subject as the only
+      // requirement.
+      repeated CustomClaim custom_claims = 1 [
+        (buf.validate.field).repeated.max_items = 20,
+        (buf.validate.field).cel = {
+          id: "custom_claims.unique_key"
+          message: "custom claims must have unique keys"
+          expression: "this.map(custom_claim, custom_claim.key).unique()"
+        }
+      ];
+    }
+    // A replacement list of ScopedPermissions.
+    //
+    // A message is used so that an unset field can be distinguished from an empty list.
+    message ScopedPermissionsList {
+      // The scoped permissions of the Tokens minted through the TrustCredential.
+      //
+      // If empty, the minted Tokens have no declared permission restrictions and their effective
+      // permissions are the owner's permissions resolved at request time.
+      //
+      // Otherwise, a minted Token's effective permissions are the intersection of these declared
+      // permissions and the owner's permissions resolved at request time.
+      //
+      // In other words, ScopedPermissions can restrict the permissions of the minted Tokens,
+      // but cannot add any permissions that the User does not already have.
+      repeated ScopedPermissions scoped_permissions = 1 [
+        (buf.validate.field).repeated.max_items = 250,
+        (buf.validate.field).cel = {
+          id: "scoped_permissions.unique_scope"
+          message: "scoped permissions must have unique scopes"
+          expression: "this.map(sp, has(sp.scope.instance) ? 'instance' : string(sp.scope.resource.resource_type) + '/' + sp.scope.resource.resource_id).unique()"
+        }
+      ];
+    }
+    // The reference to the TrustCredential to update.
+    TrustCredentialRef trust_credential_ref = 1 [(buf.validate.field).required = true];
+    // The name of the TrustCredential.
+    //
+    // If not set, the name is not updated.
+    optional string name = 2 [
+      (buf.validate.field).string.min_len = 3,
+      (buf.validate.field).string.max_len = 256
+    ];
+    // The WorkloadIdentityIssuer whose OIDC tokens the TrustCredential accepts.
+    //
+    // If not set, the issuer is not updated. The same pairing as on creation applies to whatever the
+    // TrustCredential holds after the update: a known issuer carries no issuer_url, and
+    // WORKLOAD_IDENTITY_ISSUER_CUSTOM requires one.
+    optional WorkloadIdentityIssuer issuer = 3 [(buf.validate.field).enum.defined_only = true];
+    // The url of the OIDC issuer whose tokens the TrustCredential accepts.
+    //
+    // If not set, the url is not updated. Set it when moving to or within
+    // WORKLOAD_IDENTITY_ISSUER_CUSTOM. Moving to a known issuer means leaving this unset rather than
+    // sending an empty string; the instance drops the url the TrustCredential used to carry.
+    optional string issuer_url = 4 [
+      (buf.validate.field).string.uri = true,
+      (buf.validate.field).string.max_len = 255
+    ];
+    // The subject that a workload's OIDC token must carry in its sub claim.
+    //
+    // If not set, the subject is not updated. It can never be cleared: a TrustCredential always
+    // pins a subject.
+    optional string subject = 5 [(buf.validate.field).string.max_len = 1000];
+    // The CustomClaims of the TrustCredential, replacing all existing CustomClaims.
+    //
+    // If not set, the CustomClaims are not updated. If set with an empty list, they are all
+    // removed, leaving subject as the only requirement.
+    CustomClaimsList custom_claims = 6;
+    // The scoped permissions of the TrustCredential, replacing all existing scoped permissions.
+    //
+    // If not set, the scoped permissions are not updated. If set with an empty list, all permission
+    // restrictions are removed from the Tokens the TrustCredential mints.
+    ScopedPermissionsList scoped_permissions = 7;
+  }
+  // The TrustCredentials to update.
+  repeated Value values = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message UpdateTrustCredentialsResponse {
+  // The updated TrustCredentials in the same order as given on the request.
+  repeated TrustCredential trust_credentials = 1 [(buf.validate.field).repeated.min_items = 1];
+}
+
+message DeleteTrustCredentialsRequest {
+  // The TrustCredentials to delete.
+  repeated TrustCredentialRef trust_credential_refs = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 250
+  ];
+}
+
+message DeleteTrustCredentialsResponse {}


### PR DESCRIPTION
This adds a service for trust credentials, which allows setting up a trust relationship to an external provider, so that it can mint short-lived tokens for a bot user.

This allows eg a Github Actions workflow to access the BSR without the user having to create a long-lived API token, by exchanging a signed JWT by the configured issuer for a short-lived BSR token.

https://docs.github.com/en/actions/concepts/security/openid-connect#how-oidc-integrates-with-github-actions